### PR TITLE
update changes

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           default: true
           override: true
           components: clippy, rustfmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
       - uses: davidB/rust-cargo-make@v1
       - uses: actions/checkout@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,22 +212,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
-
-[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,21 +345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,12 +371,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
+name = "futures"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -415,6 +400,35 @@ name = "futures-core"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -427,6 +441,9 @@ name = "futures-task"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "futures-util"
@@ -434,10 +451,18 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project 1.0.2",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
 ]
 
 [[package]]
@@ -450,17 +475,18 @@ dependencies = [
  "daemonize",
  "ed25519-dalek",
  "env_logger",
+ "futures",
  "helium-proto",
  "log",
  "longfi",
  "lorawan",
- "openssl",
  "prost",
  "rand",
  "reqwest",
  "semtech-udp",
  "semver",
  "serde",
+ "serde_json",
  "structopt",
  "syslog",
  "thiserror",
@@ -613,19 +639,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
-dependencies = [
- "bytes 0.5.6",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-tls",
 ]
 
 [[package]]
@@ -798,10 +811,22 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio-named-pipes"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
+dependencies = [
+ "log",
+ "mio",
+ "miow 0.3.6",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -828,28 +853,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "miow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+dependencies = [
+ "socket2",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
-
-[[package]]
-name = "native-tls"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fcc7939b5edc4e4f86b1b4a04bb1498afaaf871b1a6691838ed06fcb48d3a3f"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
 
 [[package]]
 name = "net2"
@@ -906,6 +923,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,49 +939,6 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "openssl"
-version = "0.10.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
-dependencies = [
- "bitflags",
- "cfg-if 0.1.10",
- "foreign-types",
- "lazy_static",
- "libc",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-
-[[package]]
-name = "openssl-src"
-version = "111.12.0+1.1.1h"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "858a4132194f8570a7ee9eb8629e85b23cbc4565f2d4a162e87556e5956abf61"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -1044,12 +1024,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,6 +1061,18 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
@@ -1227,21 +1213,18 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1257,43 +1240,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
-name = "schannel"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
-dependencies = [
- "lazy_static",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-
-[[package]]
-name = "security-framework"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semtech-udp"
@@ -1587,6 +1537,7 @@ dependencies = [
  "libc",
  "memchr",
  "mio",
+ "mio-named-pipes",
  "mio-uds",
  "num_cpus",
  "pin-project-lite 0.1.11",
@@ -1605,16 +1556,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -1757,12 +1698,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
-# cargo-features = ["strip"]
+cargo-features = ["strip"]
 
 [package]
 name = "gateway-rs"
@@ -21,30 +21,31 @@ structopt = "0.3"
 semver = "0.11"
 config = {version="0.10", default-features=false, features=["toml"]}
 serde = "1"
-tokio = { version = "0.2", default-features=false, features=["macros", "signal", "rt-threaded", "fs"] }
+serde_json = "1"
+tokio = { version = "0.2", default-features=false, features=["macros", "signal", "rt-threaded", "process"] }
+futures = "*"
 triggered = "0.1"
 log  = "0.4"
 env_logger = {version = "0.8", default-features = false, features = ["humantime"]}
 syslog = {version = "5"}
 thiserror = "1.0"
-openssl = {version="0.10", features=["vendored"]}
 bs58 = {version = "0.3.0", features=["check"]}
 base64 = "0"
 rand = "*"
 ed25519-dalek = "1.0"
 prost = "*"
 daemonize = "0.4"
-reqwest = {version = "0.10", features=["native-tls", "json"]}
+reqwest = {version = "0.10", default-features = false, features=["json"]}
 lorawan = { package = "lorawan", path = "lorawan" }
 semtech-udp = { git = "https://github.com/helium/semtech-udp.git", branch = "master", features=["server"] }
 helium-proto = { git = "https://github.com/helium/proto", branch="master"}
 longfi = { git = "https://github.com/helium/longfi-rs", branch = "main" }
 
 [profile.release]
-opt-level = 'z'
+opt-level = "z"
 lto = true
 codegen-units = 1
-panic = 'abort'
+panic = "abort"
 # debug = true
-# strip = "debuginfo"
+strip = "symbols"
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/cmd/key.rs
+++ b/src/cmd/key.rs
@@ -1,4 +1,4 @@
-use crate::{result::Result, settings::Settings};
+use crate::{error::Result, settings::Settings};
 use structopt::StructOpt;
 
 /// Commands on gateway keys

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,2 +1,3 @@
 pub mod key;
 pub mod server;
+pub mod update;

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -1,4 +1,4 @@
-use crate::{result::Result, server, settings::Settings};
+use crate::{error::Result, server, settings::Settings};
 use structopt::StructOpt;
 
 /// Run the gateway service

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -1,0 +1,108 @@
+use crate::{
+    error::Result,
+    releases::{self, Channel},
+    settings::{version, Settings},
+};
+use futures::{StreamExt, TryStreamExt};
+use std::{env, path::PathBuf};
+use structopt::StructOpt;
+
+/// Commands for gateway updates
+#[derive(Debug, StructOpt)]
+pub enum Cmd {
+    List(List),
+    Download(Download),
+}
+
+/// List available updates.
+#[derive(Debug, StructOpt)]
+pub struct List {
+    /// Channel to list updates for (defaults to 'update.channel' config file setting)
+    #[structopt(long)]
+    channel: Option<Channel>,
+
+    /// Number of entries to list (default 10)
+    #[structopt(short = "n")]
+    count: Option<usize>,
+
+    /// Platform to list entries for (defaults to 'update.platform' config file setting)
+    #[structopt(long)]
+    platform: Option<String>,
+}
+
+/// Download an updates. This does not install the update
+#[derive(Debug, StructOpt)]
+pub struct Download {
+    // Version of the app to download
+    version: semver::Version,
+    /// Channel to download updates from (defaults to 'update.channel' config file setting)
+    #[structopt(long)]
+    channel: Option<Channel>,
+
+    /// Path to download update to (defaults to current directory)
+    #[structopt(long)]
+    path: Option<PathBuf>,
+}
+
+impl Cmd {
+    pub async fn run(&self, settings: Settings) -> Result {
+        match self {
+            Cmd::List(cmd) => cmd.run(settings).await,
+            Cmd::Download(cmd) => cmd.run(settings).await,
+        }
+    }
+}
+
+impl List {
+    pub async fn run(&self, settings: Settings) -> Result {
+        let channel = self.channel.clone().unwrap_or(settings.update.channel);
+        let platform = self.platform.clone().unwrap_or(settings.update.platform);
+        let mut releases =
+            releases::filtered(releases::all(settings.update.url.to_string()), move |r| {
+                r.in_channel(&channel) && r.asset_for_platform(&platform).is_some()
+            })
+            .take(self.count.unwrap_or(10));
+        while let Some(Ok(release)) = releases.next().await {
+            if version() == release.version {
+                println!("{} (*)", release.version);
+            } else {
+                println!("{}", release.version);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Download {
+    pub async fn run(&self, settings: Settings) -> Result {
+        let channel = self.channel.clone().unwrap_or(settings.update.channel);
+        let platform = settings.update.platform.clone();
+        let version = self.version.clone();
+        let mut releases =
+            releases::filtered(releases::all(settings.update.url.to_string()), move |r| {
+                r.version == version
+                    && r.in_channel(&channel)
+                    && r.asset_for_platform(&platform).is_some()
+            });
+        let platform = settings.update.platform.clone();
+        match releases.try_next().await {
+            Ok(Some(release)) => {
+                let asset = release
+                    .asset_for_platform(&platform)
+                    .expect("release asset");
+                let download_path = self
+                    .path
+                    .as_ref()
+                    .unwrap_or(&env::current_dir()?)
+                    .join(&asset.name);
+                match asset.download(&download_path).await {
+                    Ok(()) => println!("Downloaded to: {}", download_path.to_string_lossy()),
+                    Err(err) => eprintln!("Failed to download update: {:?}", err),
+                }
+            }
+            Ok(None) => eprintln!("No release found"),
+            Err(err) => eprintln!("Error finding release: {:?}", err),
+        }
+        Ok(())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,10 @@
 use std::net;
 use thiserror::Error;
 
+pub type Result<T = ()> = std::result::Result<T, Error>;
+
 #[derive(Error, Debug)]
-pub enum GWError {
+pub enum Error {
     #[error("config error")]
     ConfigError(#[from] config::ConfigError),
     #[error("server error")]
@@ -15,45 +17,47 @@ pub enum GWError {
     LfcError(#[from] longfi::LfcError),
     #[error("ed25519 error")]
     ED2519Error(#[from] ed25519_dalek::ed25519::Error),
+    #[error("json error")]
+    JSONError(#[from] serde_json::Error),
 }
 
-impl From<net::AddrParseError> for GWError {
+impl From<net::AddrParseError> for Error {
     fn from(v: net::AddrParseError) -> Self {
         Self::ServerError(v.to_string())
     }
 }
 
-impl From<tokio::sync::broadcast::RecvError> for GWError {
+impl From<tokio::sync::broadcast::RecvError> for Error {
     fn from(v: tokio::sync::broadcast::RecvError) -> Self {
         Self::ServerError(v.to_string())
     }
 }
 
-impl From<lorawan::LoraWanError> for GWError {
+impl From<lorawan::LoraWanError> for Error {
     fn from(v: lorawan::LoraWanError) -> Self {
         Self::ServerError(v.to_string())
     }
 }
 
-impl From<semtech_udp::server_runtime::Error> for GWError {
+impl From<semtech_udp::server_runtime::Error> for Error {
     fn from(v: semtech_udp::server_runtime::Error) -> Self {
         Self::ServerError(v.to_string())
     }
 }
 
-impl From<prost::EncodeError> for GWError {
+impl From<prost::EncodeError> for Error {
     fn from(v: prost::EncodeError) -> Self {
         Self::ServerError(v.to_string())
     }
 }
 
-impl From<prost::DecodeError> for GWError {
+impl From<prost::DecodeError> for Error {
     fn from(v: prost::DecodeError) -> Self {
         Self::ServerError(v.to_string())
     }
 }
 
-impl From<daemonize::DaemonizeError> for GWError {
+impl From<daemonize::DaemonizeError> for Error {
     fn from(v: daemonize::DaemonizeError) -> Self {
         Self::ServerError(v.to_string())
     }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1,4 +1,4 @@
-use crate::{keypair, result::Result, router, settings::Settings};
+use crate::{error::Result, keypair, router, settings::Settings};
 use helium_proto::{packet::PacketType, Packet as LoraPacket, Region};
 use log::{debug, info, warn};
 use semtech_udp::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,18 @@ pub mod cmd;
 pub mod error;
 pub mod gateway;
 pub mod keypair;
-pub mod result;
+pub mod releases;
 pub mod router;
 pub mod server;
 pub mod settings;
 pub mod updater;
+
+use crate::error::Result;
+use futures::{Future as StdFuture, Stream as StdStream};
+use std::pin::Pin;
+
+/// A type alias for `Future` that may return `crate::error::Error`
+pub type Future<T> = Pin<Box<dyn StdFuture<Output = Result<T>> + Send>>;
+
+/// A type alias for `Stream` that may result in `crate::error::Error`
+pub type Stream<T> = Pin<Box<dyn StdStream<Item = Result<T>> + Send>>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use gateway_rs::{
     cmd,
-    result::Result,
+    error::Result,
     settings::{LogMethod, Settings},
 };
 use std::path::PathBuf;
@@ -25,6 +25,7 @@ pub struct Cli {
 #[derive(Debug, StructOpt)]
 pub enum Cmd {
     Key(cmd::key::Cmd),
+    Update(cmd::update::Cmd),
     Server(cmd::server::Cmd),
 }
 
@@ -82,6 +83,7 @@ pub fn main() -> Result {
 pub async fn run(cli: Cli, settings: Settings, shutdown_listener: &triggered::Listener) -> Result {
     match cli.cmd {
         Cmd::Key(cmd) => cmd.run(settings).await,
+        Cmd::Update(cmd) => cmd.run(settings).await,
         Cmd::Server(cmd) => cmd.run(shutdown_listener, settings).await,
     }
 }

--- a/src/releases.rs
+++ b/src/releases.rs
@@ -1,0 +1,205 @@
+use crate::{
+    error::{Error, Result},
+    Future, Stream,
+};
+use futures::{future, stream, FutureExt, StreamExt, TryFutureExt};
+use semver::Version;
+use serde::{de, Deserialize, Deserializer};
+use std::{fmt, path::Path, str::FromStr};
+use tokio::process;
+
+pub const GH_PAGE_SIZE: u8 = 10;
+
+/// Filter a given stream of releases with a given filter function.
+pub fn filtered<F>(releases: Stream<Release>, filter: F) -> Stream<Release>
+where
+    F: Fn(&Release) -> bool + Sync + 'static + std::marker::Send,
+{
+    releases
+        .filter(move |release| future::ready(release.as_ref().map_or(false, |r| filter(&r))))
+        .boxed()
+}
+
+/// Get a stream of all releases
+pub fn all(url: String) -> Stream<Release> {
+    fetch_releases(url, 1)
+        .map_ok(move |((url, page), items)| {
+            stream::try_unfold(
+                ((url, page), items),
+                |((url, page), mut items)| async move {
+                    match items.pop() {
+                        Some(item) => Ok(Some((item, ((url, page), items)))),
+                        None => {
+                            let ((url, page), mut items) = fetch_releases(url, page + 1).await?;
+                            match items.pop() {
+                                Some(item) => Ok(Some((item, ((url, page), items)))),
+                                None => Ok(None),
+                            }
+                        }
+                    }
+                },
+            )
+        })
+        .try_flatten_stream()
+        .boxed()
+}
+
+fn fetch_releases(url: String, page: u32) -> Future<((String, u32), Vec<Release>)> {
+    let curl_url = format!("{}?per_page={}&page={}", url, GH_PAGE_SIZE, page);
+    process::Command::new("curl")
+        .kill_on_drop(true)
+        .args(&["-H", "Accept: application/vnd.github.v3+json"])
+        .arg("-f")
+        .arg(&curl_url)
+        .output()
+        .map(move |result| match result {
+            Ok(output) => {
+                let mut items: Vec<Release> = serde_json::from_slice(&output.stdout)?;
+                items.reverse();
+                Ok(((url, page), items))
+            }
+            Err(err) => Err(Error::from(err)),
+        })
+        .boxed()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelParseError(String);
+
+impl fmt::Display for ChannelParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid channel: {}", self.0)
+    }
+}
+
+/// Represents a release channel
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Channel {
+    Alpha,
+    Beta,
+    Release,
+}
+
+impl fmt::Display for Channel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Channel::Alpha => "alpha",
+            Channel::Beta => "beta",
+            Channel::Release => "release",
+        };
+        f.write_str(s)
+    }
+}
+
+impl FromStr for Channel {
+    type Err = ChannelParseError;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "alpha" => Ok(Channel::Alpha),
+            "beta" => Ok(Channel::Beta),
+            "release" => Ok(Channel::Release),
+            invalid => Err(ChannelParseError(invalid.to_string())),
+        }
+    }
+}
+
+/// Represeents a versioned release  with one or more assets
+#[derive(Debug, Deserialize)]
+pub struct Release {
+    /// The version of the release
+    #[serde(deserialize_with = "deserialize_version", rename = "tag_name")]
+    pub version: Version,
+    /// The list of assets for the release
+    pub assets: Vec<ReleaseAsset>,
+}
+
+fn deserialize_version<'de, D>(d: D) -> std::result::Result<Version, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(d)?;
+    let version_str = match s.strip_prefix("v") {
+        Some(v) => v,
+        None => &s,
+    };
+    version_str
+        .parse()
+        .map_err(|e| de::Error::custom(format!("invalid release format \"{}\": {}", s, e)))
+}
+
+impl Release {
+    /// Checks whether a release is in the given channel. For the release
+    /// channel any non prerelease version is considered good. For alpha/beta
+    /// the alpha or beta strings have to be part of the "pre" release
+    /// identifiers of the version.
+    pub fn in_channel(&self, channel: &Channel) -> bool {
+        match channel {
+            Channel::Release => !self.version.is_prerelease(),
+            Channel::Alpha | Channel::Beta => {
+                use semver::Identifier;
+                let tag = channel.to_string();
+                for identifier in &self.version.pre {
+                    if let Identifier::AlphaNumeric(v) = identifier {
+                        if v.contains(&tag) {
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
+        }
+    }
+
+    pub fn asset_for_platform(&self, platform: &str) -> Option<&ReleaseAsset> {
+        let package_name = format!(
+            "helium-gateway-v{}-{}.ipk",
+            self.version.to_string(),
+            platform
+        );
+        self.asset_named(&package_name)
+    }
+
+    /// Find an asset with a given name in this release. Returns None if no such
+    /// asset was found.
+    pub fn asset_named(&self, name: &str) -> Option<&ReleaseAsset> {
+        for asset in &self.assets {
+            if asset.name == name {
+                return Some(&asset);
+            }
+        }
+        None
+    }
+}
+
+/// A release asset is a named, downloadable file that can be installed on a
+/// system.
+#[derive(Debug, Deserialize)]
+pub struct ReleaseAsset {
+    pub name: String,
+    #[serde(rename = "browser_download_url")]
+    pub download_url: String,
+    pub size: usize,
+}
+
+impl ReleaseAsset {
+    /// Downloads the asset to a given destination.
+    pub async fn download(&self, dest: &Path) -> Result {
+        process::Command::new("curl")
+            .kill_on_drop(true)
+            .arg("-s")
+            .arg("-L")
+            .args(&["-o", &dest.to_string_lossy()])
+            .arg(&self.download_url)
+            .status()
+            .map(|status| match status {
+                Ok(exit_status) if exit_status.success() => Ok(()),
+                Ok(exit_status) => Err(Error::ServerError(format!(
+                    "failed to download asset {}: {:?}",
+                    self.download_url,
+                    exit_status.code()
+                ))),
+                Err(err) => Err(Error::from(err)),
+            })
+            .await
+    }
+}

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,1 +1,0 @@
-pub type Result<T = ()> = std::result::Result<T, crate::error::GWError>;

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,4 +1,4 @@
-use crate::{keypair, result::Result, settings::Settings};
+use crate::{error::Result, keypair, settings::Settings};
 use helium_proto::{
     blockchain_state_channel_message_v1::Msg, routing_information::Data as RoutingData,
     BlockchainStateChannelMessageV1, BlockchainStateChannelPacketV1,
@@ -25,7 +25,6 @@ pub struct Response(BlockchainStateChannelMessageV1);
 pub struct Routing(RoutingInformation);
 
 pub use helium_proto::Region;
-pub use reqwest::Certificate;
 pub use reqwest::Url;
 
 impl Client {
@@ -36,15 +35,11 @@ impl Client {
             HeaderName::from_static(&AGENT_ID_HEADER),
             HeaderValue::from_str(&settings.keypair.to_string()).expect("public key not available"),
         );
-        let mut builder = reqwest::Client::builder()
-            .danger_accept_invalid_hostnames(true)
+        let builder = reqwest::Client::builder()
             .default_headers(default_headers)
             .user_agent(USER_AGENT)
             .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT))
             .http2_prior_knowledge();
-        for cert in &settings.root_certs {
-            builder = builder.add_root_certificate(cert.clone());
-        }
         Ok(Self(builder.build()?))
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,9 @@
-use crate::{gateway::Gateway, result::Result, settings::Settings, updater::Updater};
+use crate::{
+    error::Result,
+    gateway::Gateway,
+    settings::{self, Settings},
+    updater::Updater,
+};
 use log::info;
 
 pub async fn run(shutdown: &triggered::Listener, settings: &Settings) -> Result {
@@ -7,7 +12,7 @@ pub async fn run(shutdown: &triggered::Listener, settings: &Settings) -> Result 
 
     info!(
         "starting server: {} id: {}",
-        env!("CARGO_PKG_VERSION"),
+        settings::version(),
         settings.keypair
     );
     tokio::try_join!(gateway.run(shutdown.clone()), updater.run(shutdown.clone())).map(|_| ())

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,31 +1,15 @@
-use crate::{result::Result, settings::Settings};
-use log::{info, warn};
-use semver::Version;
-use serde::{de, Deserialize, Deserializer};
-use std::{
-    env, fmt, io,
-    path::{Path, PathBuf},
-    process,
+use crate::{
+    error::Result,
+    releases::{self, Channel},
+    settings::{version, Settings},
 };
-use tokio::time;
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub enum Channel {
-    Alpha,
-    Beta,
-    Release,
-}
-
-impl fmt::Display for Channel {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = match self {
-            Channel::Alpha => "alpha",
-            Channel::Beta => "beta",
-            Channel::Release => "release",
-        };
-        f.write_str(s)
-    }
-}
+use futures::TryStreamExt;
+use log::{info, warn};
+use std::{
+    env, io,
+    path::{Path, PathBuf},
+};
+use tokio::{process, time};
 
 #[derive(Debug)]
 pub struct Updater {
@@ -79,25 +63,22 @@ impl Updater {
                     // Get teh current cersion and find teh first replease
                     // version in the settings channel that is newer than the
                     // package version.
-                    let current_version = Version::parse(env!("CARGO_PKG_VERSION")).expect("semver package version");
-                    let mut release_list = ReleaseList::new(self.client.clone(), self.url.clone());
-                    match release_list.first(|r| {
-                        r.in_channel(&self.channel) && r.version > current_version
-                    }).await {
+                    let current_version = version();
+                    let channel = self.channel.clone();
+                    match releases::filtered(releases::all(self.url.to_string()), move | r | {
+                        r.in_channel(&channel) && r.version > current_version
+                    }).try_next().await {
                         Ok(Some(release)) => {
-                            let package_name = format!("helium-gateway-v{}-{}.ipk",
-                                                       release.version.to_string(),
-                                                       self.platform);
                             // Check for an asset given teh assumed name for the package
-                            match release.asset_named(&package_name) {
+                            match release.asset_for_platform(&self.platform) {
                                 Some(asset) => {
-                                    info!("downloading update {:?}", package_name);
-                                    let download_path = self.download_path(&package_name);
+                                    info!("downloading update {:?}", asset.name);
+                                    let download_path = self.download_path(&asset.name);
                                     asset.download(&download_path).await?;
-                                    info!("installing update {:?}", package_name);
+                                    info!("installing update {:?}", asset.name);
                                     return self.install(&download_path).await;
                                 },
-                                None => warn!("no release asset found for {}", package_name)
+                                None => warn!("no release asset found for {} in release {}", self.platform, release.version),
                             }
                         },
                         Ok(None) => info!("no update found"),
@@ -123,6 +104,7 @@ impl Updater {
         match process::Command::new(&self.install_command)
             .arg(download_path)
             .output()
+            .await
         {
             Ok(output) => {
                 if output.status.success() {
@@ -136,169 +118,5 @@ impl Updater {
             }
             Err(err) => Err(err.into()),
         }
-    }
-}
-
-/// Represeents a versioned release  with one or more assets
-#[derive(Debug, Deserialize)]
-pub struct Release {
-    /// The version of the release
-    #[serde(deserialize_with = "deserialize_version", rename = "tag_name")]
-    version: Version,
-    /// The list of assets for the release
-    assets: Vec<ReleaseAsset>,
-}
-
-fn deserialize_version<'de, D>(d: D) -> std::result::Result<Version, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s = String::deserialize(d)?;
-    let version_str = match s.strip_prefix("v") {
-        Some(v) => v,
-        None => &s,
-    };
-    version_str
-        .parse()
-        .map_err(|e| de::Error::custom(format!("invalid release format \"{}\": {}", s, e)))
-}
-
-impl Release {
-    /// Checks whether a release is in the given channel. For the release
-    /// channel any non prerelease version is considered good. For alpha/beta
-    /// the alpha or beta strings have to be part of the "pre" release
-    /// identifiers of the version.
-    pub fn in_channel(&self, channel: &Channel) -> bool {
-        match channel {
-            Channel::Release => !self.version.is_prerelease(),
-            Channel::Alpha | Channel::Beta => {
-                use semver::Identifier;
-                let tag = channel.to_string();
-                for identifier in &self.version.pre {
-                    if let Identifier::AlphaNumeric(v) = identifier {
-                        if v.contains(&tag) {
-                            return true;
-                        }
-                    }
-                }
-                false
-            }
-        }
-    }
-
-    /// Find an asset with a given name in this release. Returns None if no such
-    /// asset was found.
-    pub fn asset_named(&self, name: &str) -> Option<&ReleaseAsset> {
-        for asset in &self.assets {
-            if asset.name == name {
-                return Some(&asset);
-            }
-        }
-        None
-    }
-}
-
-/// A release asset is a named, downloadable file that can be installed on a
-/// system.
-#[derive(Debug, Deserialize)]
-pub struct ReleaseAsset {
-    pub name: String,
-    #[serde(rename = "browser_download_url")]
-    pub download_url: String,
-    pub size: usize,
-}
-
-impl ReleaseAsset {
-    /// Downloads the asset to a given destination.
-    pub async fn download(&self, dest: &Path) -> Result {
-        use tokio::{fs::File, io::BufWriter, prelude::*};
-        let client = reqwest::Client::new();
-        match client.get(&self.download_url).send().await {
-            Ok(mut response) => {
-                let file = File::create(&dest).await?;
-                let mut writer = BufWriter::new(file);
-                let mut bytes_written = 0;
-                while let Some(chunk) = response.chunk().await? {
-                    writer.write_all(&chunk).await?;
-                    bytes_written += chunk.len();
-                }
-                writer.flush().await?;
-                if bytes_written != self.size {
-                    return Err(io::Error::new(
-                        io::ErrorKind::UnexpectedEof,
-                        format!(
-                            "expected {} download bytes, but got {}",
-                            self.size, bytes_written
-                        ),
-                    )
-                    .into());
-                }
-                Ok(())
-            }
-            Err(err) => Err(err.into()),
-        }
-    }
-}
-
-/// A release list represents a list of Github releases. The release list is
-/// lazy and will request the API for more releases as they are requested.
-#[derive(Debug)]
-pub struct ReleaseList {
-    client: reqwest::Client,
-    url: reqwest::Url,
-    next_page: u8,
-    current_page: Vec<Release>,
-    finished: bool,
-}
-
-const GH_PAGE_SIZE: u8 = 10;
-
-impl ReleaseList {
-    /// Creates a new release list given a request client.
-    pub fn new(client: reqwest::Client, url: reqwest::Url) -> Self {
-        Self {
-            client,
-            url,
-            next_page: 1,
-            current_page: vec![],
-            finished: false,
-        }
-    }
-
-    /// Returns the first release that matches the given filter. Returns None if
-    /// the filter never returns true and the release list is exhausted.
-    pub async fn first<F>(&mut self, needle: F) -> Result<Option<Release>>
-    where
-        F: Fn(&Release) -> bool,
-    {
-        while let Some(release) = self.next().await? {
-            if needle(&release) {
-                return Ok(Some(release));
-            }
-        }
-        Ok(None)
-    }
-
-    /// Fetches the next release from the release list. Returns None if no more releases are available.
-    pub async fn next(&mut self) -> Result<Option<Release>> {
-        if self.finished {
-            return Ok(None);
-        };
-        if self.current_page.is_empty() {
-            let mut next_page = self
-                .client
-                .get(self.url.clone())
-                .query(&[("per_page", GH_PAGE_SIZE), ("page", self.next_page)])
-                .send()
-                .await?
-                .error_for_status()?
-                .json::<Vec<Release>>()
-                .await?;
-            self.finished = next_page.len() < GH_PAGE_SIZE as usize;
-            next_page.reverse();
-            self.current_page = next_page;
-            self.next_page += 1;
-        };
-        Ok(self.current_page.pop())
     }
 }


### PR DESCRIPTION
* Adds an update command with subcommands for listing, downloading udpates from a given channel (for a platform).

* Refactors to remove openssl as a requirement. We use a callout to curl to make downloads/update requests hapen

* Use nightly toolchain for strip functionality on release builds