### PR TITLE
Fix dragino platform name

### DIFF
--- a/package/dragino/data/etc/helium_gateway/settings.toml
+++ b/package/dragino/data/etc/helium_gateway/settings.toml
@@ -4,4 +4,4 @@ level = "info"
 timestamp = false
 
 [update]
-platform = "mips_24kc"
+platform = "dragino"


### PR DESCRIPTION
The dragino platform name needs to be set to `dragino` in order for the release updater to find the release