### PR TITLE
Add conffiles control file for ipk packages

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -80,6 +80,8 @@ script = '''
 	# install control files
 	mkdir -p ${PKG_BUILD_DIR}/control
 	export CARGO_MAKE_PROFILE CARGO_MAKE_CRATE_VERSION
+        envsubst < config/conffiles > ${PKG_BUILD_DIR}/control/conffiles
+        chmod +x ${PKG_BUILD_DIR}/control/conffiles
 	for control_file in control preinst postinst prerm; do
 	    envsubst < ${PKG_SRC_DIR}/control/${control_file} > ${PKG_BUILD_DIR}/control/${control_file}
 	    chmod +x ${PKG_BUILD_DIR}/control/${control_file}

--- a/config/conffiles
+++ b/config/conffiles
@@ -1,0 +1,1 @@
+/etc/helium_gateway/settings.toml


### PR DESCRIPTION
Add 'conffiles' control file to ipk package build and includes settings.toml in the conffiles. This address issue #40 where the settings.toml file is overwritten on upgrade.

This will apply to all ipk packages.

Tested on Dragino LPS8 and RAK 7258 (WisGate Edge Lite) to confirm upgrade from 1.0.0-alpha.6 upgrade to .8 did not overwrite settings.toml. 