### PR TITLE
Do not stop the service in prerm

### DIFF
--- a/package/dragino/control/prerm
+++ b/package/dragino/control/prerm
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-/etc/init.d/helium_gateway stop  > /dev/null 2>&1
 /etc/init.d/helium_gateway disable
 

--- a/package/klkgw/control/prerm
+++ b/package/klkgw/control/prerm
@@ -1,6 +1,4 @@
 #!/bin/sh
 
-/etc/init.d/helium_gateway stop
-
 rm -f /etc/rcU.d/S60helium_gateway
 rm -f /etc/rcK.d/K60helium_gateway

--- a/package/mtcdt/control/prerm
+++ b/package/mtcdt/control/prerm
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-/etc/init.d/helium_gateway stop
 /usr/sbin/update-rc.d helium_gateway -f remove
 
 

--- a/package/ramips_24kec/control/prerm
+++ b/package/ramips_24kec/control/prerm
@@ -1,5 +1,4 @@
 #!/bin/sh
 
-/etc/init.d/helium_gateway stop
 /etc/init.d/helium_gateway disable
 


### PR DESCRIPTION
Stopping the service in prerm breaks the upgrade path. The postinst step will restart/reload the service which should pick up the newer version.

Fixes: #48 