### PR TITLE
bump crypto, change default key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
 ]
@@ -251,12 +251,14 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "281d926f72b42bf3ba840b88cd53e39f36be9f66e34c8df3fb336372b3753d41"
+checksum = "b32a398eb1ccfbe7e4f452bc749c44d38dd732e9a253f19da224c416f00ee7f4"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.3",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -341,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c4363c082db1a39dc354b9693923252c333bd41c918a64639da87aec1a6288"
+checksum = "05cb0ed2d2ce37766ac86c05f66973ace8c51f7f1533bedce8fb79e2b54b3f14"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -367,7 +369,7 @@ source = "git+https://github.com/helium/ed25519-dalek?branch=madninja/bump_rand#
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand 0.8.4",
+ "rand",
  "serde",
  "sha2",
  "zeroize",
@@ -381,9 +383,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59029dd05f60215bbe37eda4b32ba1a142abc8b01a938955b20b92ff0d713e8e"
+checksum = "dd035cb119cbc25e91bb6f1abbfe341388ddb47a1fe5e77ca6bcbe231e87580b"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -527,7 +529,7 @@ dependencies = [
  "longfi",
  "lorawan",
  "prost",
- "rand 0.8.4",
+ "rand",
  "semtech-udp",
  "semver",
  "serde",
@@ -611,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heck"
@@ -626,8 +628,8 @@ dependencies = [
 
 [[package]]
 name = "helium-crypto"
-version = "0.1.0"
-source = "git+https://github.com/helium/helium-crypto-rs?tag=v0.1.0#22bb781a950e07500301cca1b130efb161ee5e70"
+version = "0.2.0"
+source = "git+https://github.com/helium/helium-crypto-rs?tag=v0.2.0#e41042936cd09f85670c9cf9927039899e9a33e8"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -655,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -732,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -952,7 +954,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "p256"
 version = "0.9.0"
-source = "git+https://github.com/helium/elliptic-curves?branch=madninja/compact_point_impl#c7fe19baf31e6d26aa6d56f89f5f00899bb996c7"
+source = "git+https://github.com/helium/elliptic-curves?branch=madninja/compact_point_impl#76f547b420d029cc9eab3a74723773feeb4a8864"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -1006,9 +1008,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -1138,37 +1140,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_hc",
 ]
 
 [[package]]
@@ -1201,15 +1180,6 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
@@ -1219,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags",
 ]
@@ -1266,7 +1236,7 @@ dependencies = [
  "arrayref",
  "base64 0.13.0",
  "num_enum",
- "rand 0.8.4",
+ "rand",
  "serde",
  "serde_json",
  "serde_repr",
@@ -1358,9 +1328,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest",
  "rand_core 0.6.3",
@@ -1526,7 +1496,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.4",
+ "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -1554,18 +1524,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1593,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.6.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea337f72e96efe29acc234d803a5981cd9a2b6ed21655cd7fc21cfe021e8ec7"
+checksum = "570c2eb13b3ab38208130eccd41be92520388791207fde783bda7c1e8ace28d4"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1705,7 +1675,7 @@ dependencies = [
  "futures-util",
  "indexmap",
  "pin-project",
- "rand 0.8.4",
+ "rand",
  "slab",
  "tokio",
  "tokio-stream",
@@ -1796,9 +1766,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
@@ -1896,11 +1866,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xorf"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc82ab7d90ea3bbf4f3e0df9243ee1b0e3d02a56c1be18cb63b0da5fba59cc9"
+checksum = "f0b223640dfbc22009679ce79f6777ae1db79add62a07345605777f69274a052"
 dependencies = [
- "rand 0.7.3",
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,12 @@ http = "*"
 log = "0.4"
 bytes = "*"
 xxhash-c = "0.8"
-xorf = "0"
+xorf = "0.7"
 angry-purple-tiger = "0"
 lorawan = { package = "lorawan", path = "lorawan" }
 semtech-udp = { version = "0", default-features=false, features=["server"] }
 helium-proto = { git = "https://github.com/helium/proto", branch="master", features=["services"]}
-helium-crypto = { git = "https://github.com/helium/helium-crypto-rs", tag = "v0.1.0"}
+helium-crypto = { git = "https://github.com/helium/helium-crypto-rs", tag = "v0.2.0"}
 longfi = { git = "https://github.com/helium/longfi-rs", branch = "main" }
 
 [profile.release]

--- a/config/default.toml
+++ b/config/default.toml
@@ -4,7 +4,7 @@
 ##   Override settings in settings.toml by putting the sections and
 ##   settings that need to be changed there.  
 
-keypair = "/etc/helium_gateway/key.bin"
+keypair = "/etc/helium_gateway/gateway_key.bin"
 listen_addr = "127.0.0.1:1680"
 region = "US915"
 

--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -26,7 +26,7 @@ const TXN_FEE_SIGNATURE_SIZE: usize = 64;
 
 impl Cmd {
     pub async fn run(&self, settings: Settings) -> Result {
-        let public_key = &settings.keypair.public_key;
+        let public_key = &settings.keypair.public_key();
         let config = TxnFeeConfig::for_address(public_key).await?;
         let mut txn = BlockchainTxnAddGatewayV1 {
             gateway: public_key.to_vec(),

--- a/src/cmd/key.rs
+++ b/src/cmd/key.rs
@@ -23,7 +23,7 @@ impl Cmd {
 
 impl Info {
     pub async fn run(&self, settings: Settings) -> Result {
-        let key = settings.keypair.public_key.to_string();
+        let key = settings.keypair.public_key().to_string();
         let table = json!({
             "address": key,
             "name": key.parse::<AnimalName>().unwrap().to_string(),

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -1,16 +1,12 @@
 use crate::*;
-use helium_crypto::{ecc_compact, Error as CryptoError, KeyType};
 use std::{convert::TryFrom, fs, path};
 
-pub type Keypair = helium_crypto::ecc_compact::Keypair;
+pub type Keypair = helium_crypto::Keypair;
 pub type PublicKey = helium_crypto::PublicKey;
 
 pub fn load_from_file(path: &str) -> error::Result<Keypair> {
     let data = fs::read(path)?;
-    match KeyType::try_from(data[0])? {
-        KeyType::EccCompact => Ok(ecc_compact::Keypair::try_from(&data[..])?),
-        _ => Err(CryptoError::invalid_keytype(data[0]).into()),
-    }
+    Ok(Keypair::try_from(&data[..])?)
 }
 
 pub fn save_to_file(keypair: &Keypair, path: &str) -> Result {

--- a/src/link_packet.rs
+++ b/src/link_packet.rs
@@ -107,7 +107,7 @@ impl LinkPacket {
         let mut router_packet = BlockchainStateChannelPacketV1 {
             packet: Some(self.packet.clone()),
             signature: vec![],
-            hotspot: keypair.public_key.to_bytes().to_vec(),
+            hotspot: keypair.public_key().to_bytes().to_vec(),
             region: region.into(),
             hold_time: 0,
         };

--- a/src/server.rs
+++ b/src/server.rs
@@ -14,7 +14,7 @@ pub async fn run(shutdown: &triggered::Listener, settings: &Settings, logger: &L
     info!(logger,
         "starting server";
         "version" => settings::version().to_string(),
-        "key" => settings.keypair.public_key.to_string(),
+        "key" => settings.keypair.public_key().to_string(),
     );
     tokio::try_join!(
         gateway.run(shutdown.clone(), logger),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use config::{Config, Environment, File};
-use helium_crypto::{ecc_compact, Network};
+use helium_crypto::{ed25519, Network};
 use helium_proto::Region;
 use http::uri::Uri;
 use rand::rngs::OsRng;
@@ -130,7 +130,7 @@ where
     match keypair::load_from_file(&s) {
         Ok(k) => Ok(Arc::new(k)),
         Err(Error::IO(io_error)) if io_error.kind() == std::io::ErrorKind::NotFound => {
-            let new_key = ecc_compact::Keypair::generate(Network::MainNet, &mut OsRng);
+            let new_key: Keypair = ed25519::Keypair::generate(Network::MainNet, &mut OsRng).into();
             keypair::save_to_file(&new_key, &s).map_err(|e| {
                 de::Error::custom(format!("unable to save key file \"{}\": {:?}", s, e))
             })?;


### PR DESCRIPTION
This PR upgrades the crypto library

**NOTE** This creates a **NEW** key file called gateway_key.bin since the previously generated key.bin is an incorrectly generated ecc_compact key.