### PR TITLE
improve logs in gateway for received frames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,7 +517,7 @@ name = "gateway-rs"
 version = "1.0.0-alpha.13"
 dependencies = [
  "angry-purple-tiger",
- "base64 0.12.3",
+ "base64 0.13.0",
  "bytes",
  "config",
  "daemonize",
@@ -1229,9 +1229,9 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "semtech-udp"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48064c08a4c802d70c7958ce764c9ca611e541b2f1e59cbe14399880dc6cfc71"
+checksum = "f4f57e39fb9043cdb9938500dfaec1909cce88e22d2dad0e4dd0b73035c6d97a"
 dependencies = [
  "arrayref",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,9 +1229,9 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "semtech-udp"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f57e39fb9043cdb9938500dfaec1909cce88e22d2dad0e4dd0b73035c6d97a"
+checksum = "da54bd93d310610de33a52c274257cceade51f678129a5787c4414193ca30dac"
 dependencies = [
  "arrayref",
  "base64 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ xxhash-c = "0.8"
 xorf = "0.7"
 angry-purple-tiger = "0"
 lorawan = { package = "lorawan", path = "lorawan" }
-semtech-udp = { version = "^0.5.2", default-features=false, features=["server"] }
+semtech-udp = { version = "^0.6", default-features=false, features=["server"] }
 helium-proto = { git = "https://github.com/helium/proto", branch="master", features=["services"]}
 helium-crypto = { git = "https://github.com/helium/helium-crypto-rs", tag = "v0.2.1"}
 longfi = { git = "https://github.com/helium/longfi-rs", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ xxhash-c = "0.8"
 xorf = "0.7"
 angry-purple-tiger = "0"
 lorawan = { package = "lorawan", path = "lorawan" }
-semtech-udp = { version = "0", default-features=false, features=["server"] }
+semtech-udp = { version = "^0.5.2", default-features=false, features=["server"] }
 helium-proto = { git = "https://github.com/helium/proto", branch="master", features=["services"]}
 helium-crypto = { git = "https://github.com/helium/helium-crypto-rs", tag = "v0.2.1"}
 longfi = { git = "https://github.com/helium/longfi-rs", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ xxhash-c = "0.8"
 xorf = "0.7"
 angry-purple-tiger = "0"
 lorawan = { package = "lorawan", path = "lorawan" }
-semtech-udp = { version = ">=0.6", default-features=false, features=["server"] }
+semtech-udp = { version = ">=0.6,<1", default-features=false, features=["server"] }
 helium-proto = { git = "https://github.com/helium/proto", branch="master", features=["services"]}
 helium-crypto = { git = "https://github.com/helium/helium-crypto-rs", tag = "v0.2.1"}
 longfi = { git = "https://github.com/helium/longfi-rs", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ xxhash-c = "0.8"
 xorf = "0.7"
 angry-purple-tiger = "0"
 lorawan = { package = "lorawan", path = "lorawan" }
-semtech-udp = { version = "^0.6", default-features=false, features=["server"] }
+semtech-udp = { version = ">=0.6", default-features=false, features=["server"] }
 helium-proto = { git = "https://github.com/helium/proto", branch="master", features=["services"]}
 helium-crypto = { git = "https://github.com/helium/helium-crypto-rs", tag = "v0.2.1"}
 longfi = { git = "https://github.com/helium/longfi-rs", branch = "main" }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -89,12 +89,7 @@ impl Gateway {
                     if let Some(rxpks) = packet.data.rxpk {
                         let mac = packet.gateway_mac;
                         for rxpk in rxpks {
-                            info!(
-                                logger,
-                                "uplink {}, from {}",
-                                rxpk,
-                                mac
-                            )
+                            info!(logger, "uplink {}, from {}", rxpk, mac)
                         }
                     }
                 }
@@ -117,7 +112,12 @@ impl Gateway {
         match downlink.to_pull_resp(false)? {
             None => return Ok(()),
             Some(txpk) => {
-                info!(logger, "rx1 downlink {} via {}", txpk, downlink_rx1.get_destination_mac());
+                info!(
+                    logger,
+                    "rx1 downlink {} via {}",
+                    txpk,
+                    downlink_rx1.get_destination_mac()
+                );
                 downlink_rx1.set_packet(txpk);
                 match downlink_rx1
                     .dispatch(Some(Duration::from_secs(DOWNLINK_TIMEOUT_SECS)))
@@ -127,7 +127,12 @@ impl Gateway {
                     Err(SemtechError::Ack(tx_ack::Error::TOO_EARLY))
                     | Err(SemtechError::Ack(tx_ack::Error::TOO_LATE)) => {
                         if let Some(txpk) = downlink.to_pull_resp(true)? {
-                            info!(logger, "rx2 downlink {} via {}", txpk, downlink_rx2.get_destination_mac());
+                            info!(
+                                logger,
+                                "rx2 downlink {} via {}",
+                                txpk,
+                                downlink_rx2.get_destination_mac()
+                            );
                             downlink_rx2.set_packet(txpk);
                             match downlink_rx2
                                 .dispatch(Some(Duration::from_secs(DOWNLINK_TIMEOUT_SECS)))

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -124,8 +124,8 @@ impl Gateway {
                     .await
                 {
                     // On a too early or too late error retry on the rx2 slot if available.
-                    Err(SemtechError::Ack(tx_ack::Error::TOO_EARLY))
-                    | Err(SemtechError::Ack(tx_ack::Error::TOO_LATE)) => {
+                    Err(SemtechError::Ack(tx_ack::Error::TooEarly))
+                    | Err(SemtechError::Ack(tx_ack::Error::TooLate)) => {
                         if let Some(txpk) = downlink.to_pull_resp(true)? {
                             info!(
                                 logger,
@@ -138,7 +138,6 @@ impl Gateway {
                                 .dispatch(Some(Duration::from_secs(DOWNLINK_TIMEOUT_SECS)))
                                 .await
                             {
-                                Err(SemtechError::Ack(tx_ack::Error::NONE)) => Ok(()),
                                 Err(err) => {
                                     warn!(logger, "ignoring rx2 downlink error: {:?}", err);
                                     Ok(())
@@ -149,7 +148,6 @@ impl Gateway {
                             Ok(())
                         }
                     }
-                    Err(SemtechError::Ack(tx_ack::Error::NONE)) => Ok(()),
                     Err(err) => {
                         warn!(logger, "ignoring rx1 downlink error: {:?}", err);
                         Ok(())

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -110,7 +110,7 @@ impl Gateway {
         );
 
         match downlink.to_pull_resp(false)? {
-            None => return Ok(()),
+            None => Ok(()),
             Some(txpk) => {
                 info!(
                     logger,

--- a/src/service/gateway.rs
+++ b/src/service/gateway.rs
@@ -49,7 +49,7 @@ impl Response {
             Some(gateway_resp_v1::Msg::RoutingStreamedResp(routings)) => {
                 debug!("Received routings");
                 Ok(&routings.routings)
-            },
+            }
             msg => Err(Error::custom(format!(
                 "Unexpected gateway message {:?}",
                 msg

--- a/src/service/gateway.rs
+++ b/src/service/gateway.rs
@@ -17,6 +17,8 @@ pub struct Streaming {
 #[derive(Debug, Clone)]
 pub struct Response(GatewayRespV1);
 
+use log::debug;
+
 impl Streaming {
     pub async fn message(&mut self) -> Result<Option<Response>> {
         match self.streaming.message().await {
@@ -44,7 +46,10 @@ impl Response {
 
     pub fn routings(&self) -> Result<&[Routing]> {
         match &self.0.msg {
-            Some(gateway_resp_v1::Msg::RoutingStreamedResp(routings)) => Ok(&routings.routings),
+            Some(gateway_resp_v1::Msg::RoutingStreamedResp(routings)) => {
+                debug!("Received routings");
+                Ok(&routings.routings)
+            },
             msg => Err(Error::custom(format!(
                 "Unexpected gateway message {:?}",
                 msg

--- a/src/service/gateway.rs
+++ b/src/service/gateway.rs
@@ -17,8 +17,6 @@ pub struct Streaming {
 #[derive(Debug, Clone)]
 pub struct Response(GatewayRespV1);
 
-use log::debug;
-
 impl Streaming {
     pub async fn message(&mut self) -> Result<Option<Response>> {
         match self.streaming.message().await {
@@ -46,10 +44,7 @@ impl Response {
 
     pub fn routings(&self) -> Result<&[Routing]> {
         match &self.0.msg {
-            Some(gateway_resp_v1::Msg::RoutingStreamedResp(routings)) => {
-                debug!("Received routings");
-                Ok(&routings.routings)
-            }
+            Some(gateway_resp_v1::Msg::RoutingStreamedResp(routings)) => Ok(&routings.routings),
             msg => Err(Error::custom(format!(
                 "Unexpected gateway message {:?}",
                 msg


### PR DESCRIPTION
Previously, every single UDP frame was printed at `info` level with the explanation "ignoring raw packet". Whether "ignoring" is good or bad isn't really clear to the user, so the new explanation is "GWMP frame received" and the log-level is bumped down to `debug`.

However, `PushData` frames are specially handled and continue to be printed at the `info` level. 

Whereas before they printed as so:
```
INFO ignoring raw packet PushData(Packet { random_token: 27289, gateway_mac: MacAddress { bytes: [0, 0, 0, 0, 4, 3, 2, 1] }, data: Data { rxpk: Some([V1(RxPkV1 { chan: 0, codr: _4_5, data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 109, 176, 243, 16, 109, 161], datr: DataRate(SF10, BW125), freq: 904.7, lsnr: 5.5, modu: LORA, rfch: 0, rssi: -112, rssis: None, size: 23, stat: OK, tmst: 454 })]), stat: None } }), module: gateway
```

Now, they display slightly more succinctly:
```
INFO uplink from MacAddress(00:00:00:00:04:03:01), 904.3 MHz, DataRate(SF10, BW125), rssic = -112, snr = 5.5,len = 23, module: gateway
```