### PR TITLE
Simplify State Channel storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
 name = "arc-swap"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ab7d9e73059c86c36473f459b52adbd99c3554a4fec492caef460806006f00"
+checksum = "e6df5aef5c5830360ce5218cecb8f018af3438af5686ae945094affc86fdec63"
 
 [[package]]
 name = "arrayref"
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e92bef8f9520d23f056674efde37622a5185c4103ca106de82f8f966ece4d"
+checksum = "51e7ef8604ba15f1ea2cef61e17577e630ee39aef7f94305d138dbf1a216ada3"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e21d2d0f22cde6e88694108429775c0219760a07779bf96503b434a03d7412"
+checksum = "2adca118c71ecd9ae094d4b68257b3fdfcb711a612b9eec7b5a0d27a5a70a5b4"
 
 [[package]]
 name = "derivative"
@@ -517,7 +517,7 @@ name = "gateway-rs"
 version = "1.0.0-alpha.16"
 dependencies = [
  "angry-purple-tiger",
- "base64 0.12.3",
+ "base64 0.13.0",
  "bytes",
  "config",
  "daemonize",
@@ -526,7 +526,7 @@ dependencies = [
  "helium-proto",
  "http",
  "http-serde",
- "log 0.3.9",
+ "log 0.4.14",
  "longfi",
  "lorawan",
  "prost",
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#1c89c47647aee253a2d4ee178d4fb65e3349515f"
+source = "git+https://github.com/helium/proto?branch=master#a2856eee49a49f7ebbe267431da28d5d0d669818"
 dependencies = [
  "bytes",
  "prost",
@@ -724,9 +724,9 @@ checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.12"
+version = "0.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f67199e765030fa08fe0bd581af683f0d5bc04ea09c2b1102012c5fb90e7fd"
+checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -804,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.101"
+version = "0.2.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
+checksum = "a2a5ac8f984bfcf3a823267e5fde638acc3325f6496633a5da6bb6eb2171e103"
 
 [[package]]
 name = "log"
@@ -1052,9 +1052,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
 dependencies = [
  "thiserror",
  "toml",
@@ -1256,9 +1256,9 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "semtech-udp"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c61a2d19db208bbb63a83f1b8f9af8d7677832b86fd746206d11f15bf1a42a5"
+checksum = "90935b06c2f2eb012a339e0a6bf1497c94ad2c07de77a8714d274c13c5b2b1b0"
 dependencies = [
  "arrayref",
  "base64 0.13.0",
@@ -1312,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "itoa",
  "ryu",
@@ -1436,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
  "libc",
  "winapi",
@@ -1750,9 +1750,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ba9ab62b7d6497a8638dfda5e5c4fb3b2d5a7fca4118f2b96151c8ef1a437e"
+checksum = "84f96e095c0c82419687c20ddf5cb3eadb61f4e1405923c9dc8e53a1adacbda8"
 dependencies = [
  "cfg-if 1.0.0",
  "log 0.4.14",
@@ -1823,9 +1823,9 @@ checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/config/default.toml
+++ b/config/default.toml
@@ -30,7 +30,6 @@ uri = "https://api.github.com/repos/helium/gateway-rs/releases"
 command = "/etc/helium_gateway/install_update"
 
 [cache]
-store = "/etc/helium_gateway/cache"
 max_packets = 20
 
 # A list of gateway service keys and urls (note https is not supported

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -28,7 +28,7 @@ impl Gateway {
             uplinks,
             downlink_mac: MacAddress::new(&[0u8; 8]),
             downlinks,
-            udp_runtime: UdpRuntime::new(settings.listen_addr).await?,
+            udp_runtime: UdpRuntime::new(&settings.listen_addr).await?,
         };
         Ok(gateway)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,9 @@ pub use msg_verify::MsgVerify;
 pub use packet::Packet;
 pub use region::Region;
 pub use settings::{CacheSettings, Settings};
-pub use state_channel::{StateChannel, StateChannelKey, StateChannelMessage};
+pub use state_channel::{
+    StateChannel, StateChannelCausality, StateChannelKey, StateChannelMessage,
+};
 
 use futures::{Future as StdFuture, Stream as StdStream};
 use std::pin::Pin;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,12 +2,7 @@ use crate::{keypair, region, releases, KeyedUri, Keypair, Region, Result};
 use config::{Config, Environment, File};
 use http::uri::Uri;
 use serde::Deserialize;
-use std::{
-    collections::HashMap,
-    net::SocketAddr,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{collections::HashMap, path::Path, sync::Arc};
 
 pub use log_method::LogMethod;
 
@@ -20,7 +15,8 @@ pub fn version() -> semver::Version {
 pub struct Settings {
     /// The listen address to use for listening for the semtech UDP packet forwarder.
     /// Default "127.0.0.1:1680"
-    pub listen_addr: SocketAddr,
+    #[serde(default = "default_listen_addr")]
+    pub listen_addr: String,
     /// The location of the keypair binary file for the gateway. Defaults to
     /// "/etc/helium_gateway/keypair.bin". If the keyfile is not found there a new
     /// one is generated and saved in that location.
@@ -83,8 +79,6 @@ pub struct UpdateSettings {
 /// Settings for cache storage
 #[derive(Debug, Deserialize, Clone)]
 pub struct CacheSettings {
-    // Path to storage folder
-    pub store: PathBuf,
     // Maximum number of packets to queue up per router client
     pub max_packets: u16,
 }
@@ -115,6 +109,10 @@ impl Settings {
     pub fn default_router(&self) -> &KeyedUri {
         &self.router[&self.update.channel.to_string()]
     }
+}
+
+fn default_listen_addr() -> String {
+    "127.0..0.1:1680".to_string()
 }
 
 pub mod log_level {


### PR DESCRIPTION
Store state channels in RAM, fix listen addrs

* Stores state channels in RAM
* Allows listen_addrs to be specified as hostnames for (e.g.) docker usage


Fixes #82 