### PR TITLE
smartharvest target: settings change to support ECC chip

### DIFF
--- a/package/smartharvest/data/etc/helium_gateway/settings.toml
+++ b/package/smartharvest/data/etc/helium_gateway/settings.toml
@@ -1,3 +1,5 @@
+keypair = "ecc://i2c-0:96&slot=0"
+
 [log]
 method = "stdio"
 level = "info"


### PR DESCRIPTION
Updating Smart Harvest target settings (`package/smartharvest/data/etc/helium_gateway/settings.toml`) to override the keypair setting to use the ECC chip