### PR TITLE
Easier starting docker specified by Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       - GW_LOG_LEVEL=info
       - GW_LOG_METHOD=stdio
-      - GW_REGION=EU868
-      - GW_TZ=Europe/Amsterdam
+      - GW_LOG_TIMESTAMP=false # Change this to true in a debug/tcpdump situation
+      - GW_REGION=EU868 # Change this to your current location. Possible values are : US915|EU868|EU433|CN470|CN779|AU915|AS923_1|AS923_2|AS923_3|AS923_4|KR920|IN865
+      - GW_TZ=Europe/Amsterdam # Change this to your current location
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+services:
+  gateway-rs:
+    image: gateway-rs:1.0.0
+    container_name: gateway-rs
+    ports:
+      - "1680:1680/udp"
+    environment:
+      - GW_LOG_LEVEL=info
+      - GW_LOG_METHOD=stdio
+      - GW_REGION=EU868
+      - GW_TZ=Europe/Amsterdam
+    restart: unless-stopped


### PR DESCRIPTION
To be able to start gateway-rs in a docker, a docker-compose is a welcome addition. I will also create the action to build the docker and host at dockerhub.

![image](https://user-images.githubusercontent.com/59441232/141340939-ce6fae72-33db-4e4d-a2f2-c3b2b590b1a7.png)
