### PR TITLE
make api listening endpoint configurable

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -17,6 +17,7 @@ keypair = "/etc/helium_gateway/gateway_key.bin"
 ## ECC608 based
 # keypair = "ecc://i2c-1:96&slot=0"
 listen = "127.0.0.1:1680"
+api_listen = "127.0.0.1:4467"
 region = "US915"
 
 [log]

--- a/config/default.toml
+++ b/config/default.toml
@@ -17,7 +17,7 @@ keypair = "/etc/helium_gateway/gateway_key.bin"
 ## ECC608 based
 # keypair = "ecc://i2c-1:96&slot=0"
 listen = "127.0.0.1:1680"
-api_listen = "127.0.0.1:4467"
+api = "127.0.0.1:4467"
 region = "US915"
 
 [log]

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,17 +1,21 @@
-use super::{ConfigReq, ConfigValue, HeightReq, HeightRes, PubkeyReq, SignReq, CONNECT_URI};
+use super::{ConfigReq, ConfigValue, HeightReq, HeightRes, PubkeyReq, SignReq};
 use crate::{PublicKey, Result};
 use helium_proto::services::local::Client;
 use std::convert::TryFrom;
 use tonic::transport::{Channel, Endpoint};
+
+const CONNECT_PREFIX: &str = "http://";
 
 pub struct LocalClient {
     client: Client<Channel>,
 }
 
 impl LocalClient {
-    pub async fn new() -> Result<Self> {
-        let addr = Endpoint::from_static(CONNECT_URI);
-        let client = Client::connect(addr).await?;
+    pub async fn new(listen_addr: String) -> Result<Self> {
+        let mut uri = CONNECT_PREFIX.to_string();
+        uri += &listen_addr;
+        let endpoint = Endpoint::from_shared(uri);
+        let client = Client::connect(endpoint.unwrap()).await?;
         Ok(Self { client })
     }
 

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -14,8 +14,8 @@ impl LocalClient {
     pub async fn new(listen_addr: String) -> Result<Self> {
         let mut uri = CONNECT_PREFIX.to_string();
         uri += &listen_addr;
-        let endpoint = Endpoint::from_shared(uri);
-        let client = Client::connect(endpoint.unwrap()).await?;
+        let endpoint = Endpoint::from_shared(uri).unwrap();
+        let client = Client::connect(endpoint).await?;
         Ok(Self { client })
     }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,9 +1,6 @@
 mod client;
 mod server;
 
-pub const LISTEN_ADDR: &str = "127.0.0.1:4467";
-pub const CONNECT_URI: &str = "http://127.0.0.1:4467";
-
 pub use client::LocalClient;
 pub use helium_proto::services::local::{
     ConfigReq, ConfigRes, ConfigValue, EcdhReq, EcdhRes, HeightReq, HeightRes, PubkeyReq,

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -1,6 +1,6 @@
 use super::{
     ConfigReq, ConfigRes, ConfigValue, EcdhReq, EcdhRes, HeightReq, HeightRes, PubkeyReq,
-    PubkeyRes, SignReq, SignRes, LISTEN_ADDR,
+    PubkeyRes, SignReq, SignRes,
 };
 use crate::{router::dispatcher, Error, Keypair, PublicKey, Result, Settings};
 use futures::TryFutureExt;
@@ -15,18 +15,20 @@ pub type ApiResult<T> = std::result::Result<Response<T>, Status>;
 pub struct LocalServer {
     dispatcher: dispatcher::MessageSender,
     keypair: Arc<Keypair>,
+    listen_addr: String,
 }
 
 impl LocalServer {
     pub fn new(dispatcher: dispatcher::MessageSender, settings: &Settings) -> Self {
         Self {
             keypair: settings.keypair.clone(),
+            listen_addr: settings.api_listen.clone(),
             dispatcher,
         }
     }
 
     pub async fn run(self, shutdown: triggered::Listener, logger: &Logger) -> Result {
-        let addr = LISTEN_ADDR.parse().unwrap();
+        let addr = self.listen_addr.parse().unwrap();
         let logger = logger.new(o!("module" => "api", "listen" => addr));
         info!(logger, "starting");
         TransportServer::builder()

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -22,7 +22,7 @@ impl LocalServer {
     pub fn new(dispatcher: dispatcher::MessageSender, settings: &Settings) -> Self {
         Self {
             keypair: settings.keypair.clone(),
-            listen_addr: settings.api_listen.clone(),
+            listen_addr: settings.api.clone(),
             dispatcher,
         }
     }

--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -23,8 +23,8 @@ pub struct Cmd {
 }
 
 impl Cmd {
-    pub async fn run(&self, _settings: Settings) -> Result {
-        let mut client = LocalClient::new().await?;
+    pub async fn run(&self, settings: Settings) -> Result {
+        let mut client = LocalClient::new(settings.api_listen.clone()).await?;
         let public_key = client.pubkey().await?;
         let config = TxnFeeConfig::from_client(&mut client).await?;
         let mut txn = BlockchainTxnAddGatewayV1 {

--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -24,7 +24,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, settings: Settings) -> Result {
-        let mut client = LocalClient::new(settings.api_listen.clone()).await?;
+        let mut client = LocalClient::new(settings.api.clone()).await?;
         let public_key = client.pubkey().await?;
         let config = TxnFeeConfig::from_client(&mut client).await?;
         let mut txn = BlockchainTxnAddGatewayV1 {

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -35,10 +35,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, settings: Settings) -> Result {
-        let mut info_cache = InfoCache::new(
-            settings.update.platform.clone(),
-            settings.api_listen.clone(),
-        );
+        let mut info_cache = InfoCache::new(settings.update.platform.clone(), settings.api.clone());
         let mut info: HashMap<String, serde_json::Value> = HashMap::new();
         for key in &self.keys.0 {
             info.insert(key.to_string(), key.to_status(&mut info_cache).await?);

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -35,7 +35,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, settings: Settings) -> Result {
-        let mut info_cache = InfoCache::new(settings.update.platform.clone());
+        let mut info_cache = InfoCache::new(settings.update.platform.clone(), settings.api_listen.clone());
         let mut info: HashMap<String, serde_json::Value> = HashMap::new();
         for key in &self.keys.0 {
             info.insert(key.to_string(), key.to_status(&mut info_cache).await?);
@@ -98,14 +98,16 @@ impl std::str::FromStr for InfoKeys {
 
 struct InfoCache {
     platform: String,
+    api_addr: String,
     public_key: Option<PublicKey>,
     height: Option<HeightRes>,
 }
 
 impl InfoCache {
-    fn new(platform: String) -> Self {
+    fn new(platform: String, api_addr: String) -> Self {
         Self {
             platform,
+            api_addr,
             public_key: None,
             height: None,
         }
@@ -115,7 +117,7 @@ impl InfoCache {
         if let Some(public_key) = &self.public_key {
             return Ok(public_key.clone());
         }
-        let mut client = LocalClient::new().await?;
+        let mut client = LocalClient::new(self.api_addr.clone()).await?;
         let public_key = client.pubkey().await?;
         self.public_key = Some(public_key.clone());
         Ok(public_key)
@@ -125,7 +127,7 @@ impl InfoCache {
         if let Some(height) = &self.height {
             return Ok(height.clone());
         }
-        let mut client = LocalClient::new().await?;
+        let mut client = LocalClient::new(self.api_addr.clone()).await?;
         let height = client.height().await?;
         self.height = Some(height.clone());
         Ok(height)

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -35,7 +35,10 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, settings: Settings) -> Result {
-        let mut info_cache = InfoCache::new(settings.update.platform.clone(), settings.api_listen.clone());
+        let mut info_cache = InfoCache::new(
+            settings.update.platform.clone(),
+            settings.api_listen.clone(),
+        );
         let mut info: HashMap<String, serde_json::Value> = HashMap::new();
         for key in &self.keys.0 {
             info.insert(key.to_string(), key.to_status(&mut info_cache).await?);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -17,10 +17,10 @@ pub struct Settings {
     /// Default "127.0.0.1:1680"
     #[serde(default = "default_listen")]
     pub listen: String,
-    /// The listen address for the grpc / jsonrpc API.
+    /// The address for the grpc / jsonrpc API.
     /// Default "127.0.0.1:4467"
-    #[serde(default = "default_api_listen")]
-    pub api_listen: String,
+    #[serde(default = "default_api")]
+    pub api: String,
     /// The location of the keypair binary file for the gateway. Defaults to
     /// "/etc/helium_gateway/keypair.bin". If the keyfile is not found there a new
     /// one is generated and saved in that location.
@@ -119,7 +119,7 @@ fn default_listen() -> String {
     "127.0.0.1:1680".to_string()
 }
 
-fn default_api_listen() -> String {
+fn default_api() -> String {
     "127.0.0.1:4467".to_string()
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -17,6 +17,10 @@ pub struct Settings {
     /// Default "127.0.0.1:1680"
     #[serde(default = "default_listen")]
     pub listen: String,
+    /// The listen address for the grpc / jsonrpc API.
+    /// Default "127.0.0.1:4467"
+    #[serde(default = "default_api_listen")]
+    pub api_listen: String,
     /// The location of the keypair binary file for the gateway. Defaults to
     /// "/etc/helium_gateway/keypair.bin". If the keyfile is not found there a new
     /// one is generated and saved in that location.
@@ -113,6 +117,10 @@ impl Settings {
 
 fn default_listen() -> String {
     "127.0.0.1:1680".to_string()
+}
+
+fn default_api_listen() -> String {
+    "127.0.0.1:4467".to_string()
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
the existing hard-coded api listening address currently conflicts with other jsonrpc and grpc api servers (namely the one running in the traditional erlang miner software). making the api listener configurable allows it to be set via the toml settings config override or the environment variables strategy.