### PR TITLE
convert configurable endpoint to port only

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -17,7 +17,7 @@ keypair = "/etc/helium_gateway/gateway_key.bin"
 ## ECC608 based
 # keypair = "ecc://i2c-1:96&slot=0"
 listen = "127.0.0.1:1680"
-api = "127.0.0.1:4467"
+api = 4467
 region = "US915"
 
 [log]

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,19 +1,16 @@
-use super::{ConfigReq, ConfigValue, HeightReq, HeightRes, PubkeyReq, SignReq};
+use super::{ConfigReq, ConfigValue, HeightReq, HeightRes, PubkeyReq, SignReq, connect_uri};
 use crate::{PublicKey, Result};
 use helium_proto::services::local::Client;
 use std::convert::TryFrom;
 use tonic::transport::{Channel, Endpoint};
-
-const CONNECT_PREFIX: &str = "http://";
 
 pub struct LocalClient {
     client: Client<Channel>,
 }
 
 impl LocalClient {
-    pub async fn new(listen_addr: String) -> Result<Self> {
-        let mut uri = CONNECT_PREFIX.to_string();
-        uri += &listen_addr;
+    pub async fn new(port: u16) -> Result<Self> {
+        let uri = connect_uri(port);
         let endpoint = Endpoint::from_shared(uri).unwrap();
         let client = Client::connect(endpoint).await?;
         Ok(Self { client })

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,4 +1,4 @@
-use super::{ConfigReq, ConfigValue, HeightReq, HeightRes, PubkeyReq, SignReq, connect_uri};
+use super::{connect_uri, ConfigReq, ConfigValue, HeightReq, HeightRes, PubkeyReq, SignReq};
 use crate::{PublicKey, Result};
 use helium_proto::services::local::Client;
 use std::convert::TryFrom;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,8 +1,7 @@
 mod client;
 mod server;
 
-const LISTEN_ADDR: &str = "127.0.0.1:";
-const URI_PREFIX: &str = "http://";
+const LISTEN_ADDR: &str = "127.0.0.1";
 
 pub use client::LocalClient;
 pub use helium_proto::services::local::{
@@ -12,14 +11,9 @@ pub use helium_proto::services::local::{
 pub use server::LocalServer;
 
 pub fn listen_addr(port: u16) -> String {
-    let mut address = LISTEN_ADDR.to_string();
-    address += &port.to_string();
-    address
+    format!("{}:{}", LISTEN_ADDR, port)
 }
 
 pub fn connect_uri(port: u16) -> String {
-    let mut uri = URI_PREFIX.to_string();
-    let addr = listen_addr(port);
-    uri += &addr;
-    uri
+    format!("http://{}", listen_addr(port))
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,9 +1,25 @@
 mod client;
 mod server;
 
+const LISTEN_ADDR: &str = "127.0.0.1:";
+const URI_PREFIX: &str = "http://";
+
 pub use client::LocalClient;
 pub use helium_proto::services::local::{
     ConfigReq, ConfigRes, ConfigValue, EcdhReq, EcdhRes, HeightReq, HeightRes, PubkeyReq,
     PubkeyRes, SignReq, SignRes,
 };
 pub use server::LocalServer;
+
+pub fn listen_addr(port: u16) -> String {
+    let mut address = LISTEN_ADDR.to_string();
+    address += &port.to_string();
+    address
+}
+
+pub fn connect_uri(port: u16) -> String {
+    let mut uri = URI_PREFIX.to_string();
+    let addr = listen_addr(port);
+    uri += &addr;
+    uri
+}

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -1,6 +1,6 @@
 use super::{
-    ConfigReq, ConfigRes, ConfigValue, EcdhReq, EcdhRes, HeightReq, HeightRes, PubkeyReq,
-    PubkeyRes, SignReq, SignRes, listen_addr,
+    listen_addr, ConfigReq, ConfigRes, ConfigValue, EcdhReq, EcdhRes, HeightReq, HeightRes,
+    PubkeyReq, PubkeyRes, SignReq, SignRes,
 };
 use crate::{router::dispatcher, Error, Keypair, PublicKey, Result, Settings};
 use futures::TryFutureExt;

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -1,6 +1,6 @@
 use super::{
     ConfigReq, ConfigRes, ConfigValue, EcdhReq, EcdhRes, HeightReq, HeightRes, PubkeyReq,
-    PubkeyRes, SignReq, SignRes,
+    PubkeyRes, SignReq, SignRes, listen_addr,
 };
 use crate::{router::dispatcher, Error, Keypair, PublicKey, Result, Settings};
 use futures::TryFutureExt;
@@ -15,20 +15,20 @@ pub type ApiResult<T> = std::result::Result<Response<T>, Status>;
 pub struct LocalServer {
     dispatcher: dispatcher::MessageSender,
     keypair: Arc<Keypair>,
-    listen_addr: String,
+    listen_port: u16,
 }
 
 impl LocalServer {
     pub fn new(dispatcher: dispatcher::MessageSender, settings: &Settings) -> Self {
         Self {
             keypair: settings.keypair.clone(),
-            listen_addr: settings.api.clone(),
+            listen_port: settings.api,
             dispatcher,
         }
     }
 
     pub async fn run(self, shutdown: triggered::Listener, logger: &Logger) -> Result {
-        let addr = self.listen_addr.parse().unwrap();
+        let addr = listen_addr(self.listen_port).parse().unwrap();
         let logger = logger.new(o!("module" => "api", "listen" => addr));
         info!(logger, "starting");
         TransportServer::builder()

--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -24,7 +24,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, settings: Settings) -> Result {
-        let mut client = LocalClient::new(settings.api.clone()).await?;
+        let mut client = LocalClient::new(settings.api).await?;
         let public_key = client.pubkey().await?;
         let config = TxnFeeConfig::from_client(&mut client).await?;
         let mut txn = BlockchainTxnAddGatewayV1 {

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -35,7 +35,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, settings: Settings) -> Result {
-        let mut info_cache = InfoCache::new(settings.update.platform.clone(), settings.api.clone());
+        let mut info_cache = InfoCache::new(settings.update.platform.clone(), settings.api);
         let mut info: HashMap<String, serde_json::Value> = HashMap::new();
         for key in &self.keys.0 {
             info.insert(key.to_string(), key.to_status(&mut info_cache).await?);
@@ -98,16 +98,16 @@ impl std::str::FromStr for InfoKeys {
 
 struct InfoCache {
     platform: String,
-    api_addr: String,
+    port: u16,
     public_key: Option<PublicKey>,
     height: Option<HeightRes>,
 }
 
 impl InfoCache {
-    fn new(platform: String, api_addr: String) -> Self {
+    fn new(platform: String, port: u16) -> Self {
         Self {
             platform,
-            api_addr,
+            port,
             public_key: None,
             height: None,
         }
@@ -117,7 +117,7 @@ impl InfoCache {
         if let Some(public_key) = &self.public_key {
             return Ok(public_key.clone());
         }
-        let mut client = LocalClient::new(self.api_addr.clone()).await?;
+        let mut client = LocalClient::new(self.port).await?;
         let public_key = client.pubkey().await?;
         self.public_key = Some(public_key.clone());
         Ok(public_key)
@@ -127,7 +127,7 @@ impl InfoCache {
         if let Some(height) = &self.height {
             return Ok(height.clone());
         }
-        let mut client = LocalClient::new(self.api_addr.clone()).await?;
+        let mut client = LocalClient::new(self.port).await?;
         let height = client.height().await?;
         self.height = Some(height.clone());
         Ok(height)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -17,10 +17,10 @@ pub struct Settings {
     /// Default "127.0.0.1:1680"
     #[serde(default = "default_listen")]
     pub listen: String,
-    /// The address for the grpc / jsonrpc API.
-    /// Default "127.0.0.1:4467"
+    /// The listening network port for the grpc / jsonrpc API.
+    /// Default 4467
     #[serde(default = "default_api")]
-    pub api: String,
+    pub api: u16,
     /// The location of the keypair binary file for the gateway. Defaults to
     /// "/etc/helium_gateway/keypair.bin". If the keyfile is not found there a new
     /// one is generated and saved in that location.
@@ -119,8 +119,8 @@ fn default_listen() -> String {
     "127.0.0.1:1680".to_string()
 }
 
-fn default_api() -> String {
-    "127.0.0.1:4467".to_string()
+fn default_api() -> u16 {
+    4467
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Making the api endpoint the gateway listens on completely configurable raises security concerns by potentially exposing the endpoint on a different listening address then the localhost. By restricting the configurability to the listening port only this allows for running the gateway alongside other services that default to the same (4467) port as well as multiple gateways on the same host (typically for testing purposes).