### PR TITLE
remove strip from manifest since stabilized

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["strip"]
-
 [package]
 name = "gateway-rs"
 description = "Helium Gateway for LoRa packet forwarders"


### PR DESCRIPTION
```
the cargo feature `strip` has been stabilized in the 1.58 release and is no longer necessary to be listed in the manifest
```