### PR TITLE
update semtech-udp to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_urlencoded",
- "sha2 0.9.9",
+ "sha2 0.10.1",
  "signature",
  "slog",
  "slog-async",
@@ -982,6 +982,12 @@ dependencies = [
  "bitfield",
  "byteorder",
 ]
+
+[[package]]
+name = "macaddr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
 
 [[package]]
 name = "mach"
@@ -1452,12 +1458,13 @@ dependencies = [
 
 [[package]]
 name = "semtech-udp"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cca2d25ca92de1e3de8173a945f69992edb64ab8c9846bf4910a992ec4da99"
+checksum = "2ed95f0f6217a1fcb524cb285de6f8523a1aeff201c243dc83124a618a984280"
 dependencies = [
  "arrayref",
  "base64",
+ "macaddr",
  "num_enum",
  "rand",
  "serde",
@@ -1465,6 +1472,7 @@ dependencies = [
  "serde_repr",
  "thiserror",
  "tokio",
+ "triggered",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ signature = "*"
 async-trait = "0"
 angry-purple-tiger = "0"
 lorawan = { package = "lorawan", path = "lorawan" }
-semtech-udp = { version = ">=0.7.3,<1", default-features=false, features=["server"] }
+semtech-udp = { version = ">=0.8,<1", default-features=false, features=["server"] }
 helium-proto = { git = "https://github.com/helium/proto", branch="master", features=["services"]}
 helium-crypto = { git = "https://github.com/helium/helium-crypto-rs", tag = "v0.3.3", features = ["ecc608"]}
 longfi = { git = "https://github.com/helium/longfi-rs", branch = "main" }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -49,7 +49,7 @@ impl Gateway {
     ) -> Result<Self> {
         let gateway = Gateway {
             uplinks,
-            downlink_mac: MacAddress::new(&[0u8; 8]),
+            downlink_mac: [0u8; 8].into(),
             messages,
             udp_runtime: UdpRuntime::new(&settings.listen).await?,
         };
@@ -80,8 +80,9 @@ impl Gateway {
 
     async fn handle_udp_event(&mut self, logger: &Logger, event: Event) -> Result {
         match event {
-            Event::UnableToParseUdpFrame(buf) => {
-                info!(logger, "ignoring semtech udp parsing error for {:?}", buf)
+            Event::UnableToParseUdpFrame(e, buf) => {
+                info!(logger, "ignoring semtech udp parsing error {e}");
+                info!(logger, "ignoring semtech udp parsing error for {buf:?}");
             }
             Event::NewClient((mac, addr)) => {
                 info!(logger, "new packet forwarder client: {}, {}", mac, addr);

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -81,8 +81,10 @@ impl Gateway {
     async fn handle_udp_event(&mut self, logger: &Logger, event: Event) -> Result {
         match event {
             Event::UnableToParseUdpFrame(e, buf) => {
-                info!(logger, "ignoring semtech udp parsing error {e}");
-                info!(logger, "ignoring semtech udp parsing error for {buf:?}");
+                info!(
+                    logger,
+                    "ignoring semtech udp parsing error {e}, raw bytes {buf:?}"
+                );
             }
             Event::NewClient((mac, addr)) => {
                 info!(logger, "new packet forwarder client: {}, {}", mac, addr);

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -81,7 +81,7 @@ impl Gateway {
     async fn handle_udp_event(&mut self, logger: &Logger, event: Event) -> Result {
         match event {
             Event::UnableToParseUdpFrame(e, buf) => {
-                info!(
+                warn!(
                     logger,
                     "ignoring semtech udp parsing error {e}, raw bytes {buf:?}"
                 );


### PR DESCRIPTION
`semtech-udp v0.8` has improvements to errors and uses the `macaddr` crate instead of the self-spun type.