### PR TITLE
Adjust region based on blockchain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#6dc60a9933628c3baf9d2f5386481f20a5d79bb8"
+source = "git+https://github.com/helium/proto?branch=master#30f17c5d1a7942297923f4e743c681c46f917fc3"
 dependencies = [
  "bytes",
  "prost",
@@ -937,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
+checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
 name = "log"
@@ -1071,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]
@@ -1312,14 +1312,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core 0.6.3",
- "rand_hc",
 ]
 
 [[package]]
@@ -1348,15 +1347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom 0.2.4",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1507,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa",
  "ryu",
@@ -2165,9 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-c-sys"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8113d3b07c5bebad59e07fd0284f285cb68e7b83f35e6d2dc695a1edccbca67a"
+checksum = "debe9444c21c1b40e4656122b08d363b5b910716d48002c0071e838b132aeae3"
 dependencies = [
  "cc",
  "libc",

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,5 +1,7 @@
-use super::{connect_uri, ConfigReq, ConfigValue, HeightReq, HeightRes, PubkeyReq, SignReq};
-use crate::{PublicKey, Result};
+use super::{
+    connect_uri, ConfigReq, ConfigValue, HeightReq, HeightRes, PubkeyReq, RegionReq, SignReq,
+};
+use crate::{PublicKey, Region, Result};
 use helium_proto::services::local::Client;
 use std::convert::TryFrom;
 use tonic::transport::{Channel, Endpoint};
@@ -37,5 +39,10 @@ impl LocalClient {
     pub async fn height(&mut self) -> Result<HeightRes> {
         let response = self.client.height(HeightReq {}).await?.into_inner();
         Ok(response)
+    }
+
+    pub async fn region(&mut self) -> Result<Region> {
+        let response = self.client.region(RegionReq {}).await?;
+        Region::from_i32(response.into_inner().region)
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,7 +6,7 @@ const LISTEN_ADDR: &str = "127.0.0.1";
 pub use client::LocalClient;
 pub use helium_proto::services::local::{
     ConfigReq, ConfigRes, ConfigValue, EcdhReq, EcdhRes, HeightReq, HeightRes, PubkeyReq,
-    PubkeyRes, SignReq, SignRes,
+    PubkeyRes, RegionReq, RegionRes, SignReq, SignRes,
 };
 pub use server::LocalServer;
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -11,9 +11,10 @@ pub use helium_proto::services::local::{
 pub use server::LocalServer;
 
 pub fn listen_addr(port: u16) -> String {
-    format!("{}:{}", LISTEN_ADDR, port)
+    format!("{LISTEN_ADDR}:{port}")
 }
 
 pub fn connect_uri(port: u16) -> String {
-    format!("http://{}", listen_addr(port))
+    let listen_addr = listen_addr(port);
+    format!("http://{listen_addr}")
 }

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -1,6 +1,6 @@
 use super::{
     listen_addr, ConfigReq, ConfigRes, ConfigValue, EcdhReq, EcdhRes, HeightReq, HeightRes,
-    PubkeyReq, PubkeyRes, SignReq, SignRes,
+    PubkeyReq, PubkeyRes, RegionReq, RegionRes, SignReq, SignRes,
 };
 use crate::{router::dispatcher, Error, Keypair, PublicKey, Result, Settings};
 use futures::TryFutureExt;
@@ -46,6 +46,17 @@ impl Api for LocalServer {
             address: self.keypair.public_key().to_vec(),
         };
         Ok(Response::new(reply))
+    }
+
+    async fn region(&self, _request: Request<RegionReq>) -> ApiResult<RegionRes> {
+        let region = self
+            .dispatcher
+            .region()
+            .map_err(|_err| Status::internal("Failed to get region"))
+            .await?;
+        Ok(Response::new(RegionRes {
+            region: region.into(),
+        }))
     }
 
     async fn sign(&self, request: Request<SignReq>) -> ApiResult<SignRes> {

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -3,7 +3,7 @@ use crate::{
     cmd::*,
     keyed_uri::KeyedUri,
     settings::{self, Settings},
-    Error, Result,
+    Error, Region, Result,
 };
 use angry_purple_tiger::AnimalName;
 use helium_crypto::PublicKey;
@@ -19,6 +19,7 @@ pub enum InfoKey {
     Key,
     Name,
     Gateway,
+    Region,
 }
 
 #[derive(Debug, Clone)]
@@ -48,6 +49,7 @@ const INFO_FW: &str = "fw";
 const INFO_KEY: &str = "key";
 const INFO_NAME: &str = "name";
 const INFO_GATEWAY: &str = "gateway";
+const INFO_REGION: &str = "region";
 
 impl fmt::Display for InfoKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -56,6 +58,7 @@ impl fmt::Display for InfoKey {
             Self::Key => INFO_KEY,
             Self::Name => INFO_NAME,
             Self::Gateway => INFO_GATEWAY,
+            Self::Region => INFO_REGION,
         };
         f.write_str(s)
     }
@@ -78,6 +81,7 @@ impl FromStr for InfoKey {
             INFO_KEY => Ok(Self::Key),
             INFO_NAME => Ok(Self::Name),
             INFO_GATEWAY => Ok(Self::Gateway),
+            INFO_REGION => Ok(Self::Region),
             invalid => Err(InfoKeyParseError(invalid.to_string())),
         }
     }
@@ -101,6 +105,7 @@ struct InfoCache {
     port: u16,
     public_key: Option<PublicKey>,
     height: Option<HeightRes>,
+    region: Option<Region>,
 }
 
 impl InfoCache {
@@ -110,6 +115,7 @@ impl InfoCache {
             port,
             public_key: None,
             height: None,
+            region: None,
         }
     }
 
@@ -150,6 +156,16 @@ impl InfoCache {
             .ok_or_else(|| Error::custom("No uri for gateway"))
             .and_then(KeyedUri::try_from)
     }
+
+    async fn region(&mut self) -> Result<Region> {
+        if let Some(region) = &self.region {
+            return Ok(region.clone());
+        }
+        let mut client = LocalClient::new(self.port).await?;
+        let region = client.region().await?;
+        self.region = Some(region.clone());
+        Ok(region)
+    }
 }
 
 impl InfoKey {
@@ -174,6 +190,9 @@ impl InfoKey {
                     "height": cache.height().await?,
                     "block_age": cache.block_age().await?,
                 })
+            }
+            Self::Region => {
+                json!(cache.region().await?.to_string())
             }
         };
         Ok(v)

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -30,7 +30,12 @@ pub struct InfoKeys(pub(crate) Vec<InfoKey>);
 #[derive(Debug, StructOpt)]
 pub struct Cmd {
     /// Information keys to fetch
-    #[structopt(long, multiple = false, default_value = "fw,key,name,gateway")]
+    #[structopt(
+        long,
+        short,
+        multiple = false,
+        default_value = "fw,key,name,region,gateway"
+    )]
     pub keys: InfoKeys,
 }
 

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -172,7 +172,9 @@ impl InfoKey {
     async fn to_status(&self, cache: &mut InfoCache) -> Result<serde_json::Value> {
         let v = match self {
             Self::Fw => {
-                json!(format!("{}-{}", cache.platform, settings::version()))
+                let platform = &cache.platform;
+                let version = settings::version();
+                json!(format!("{platform}-{version}"))
             }
             Self::Key => {
                 json!(cache.public_key().await?.to_string())

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -158,12 +158,12 @@ impl InfoCache {
     }
 
     async fn region(&mut self) -> Result<Region> {
-        if let Some(region) = &self.region {
-            return Ok(region.clone());
+        if let Some(region) = self.region {
+            return Ok(region);
         }
         let mut client = LocalClient::new(self.port).await?;
         let region = client.region().await?;
-        self.region = Some(region.clone());
+        self.region = Some(region);
         Ok(region)
     }
 }

--- a/src/keyed_uri.rs
+++ b/src/keyed_uri.rs
@@ -34,7 +34,7 @@ where
     let key_string = String::deserialize(d)?;
     match key_string.parse() {
         Ok(key) => Ok(Arc::new(key)),
-        Err(err) => Err(de::Error::custom(format!("invalid pubkey: \"{}\"", err))),
+        Err(err) => Err(de::Error::custom(format!("invalid pubkey: \"{err}\""))),
     }
 }
 

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -40,7 +40,7 @@ impl KeypairArgs {
                 || Ok(HashMap::new()),
                 serde_urlencoded::from_str::<HashMap<String, String>>,
             )
-            .map_err(|err| format!("invalid keypair url \"{}\": {:?}", url, err))?;
+            .map_err(|err| format!("invalid keypair url \"{url}\": {err:?}"))?;
         Ok(Self(args))
     }
 
@@ -53,7 +53,7 @@ impl KeypairArgs {
             .get(name)
             .map(|s| s.parse::<T>())
             .unwrap_or(Ok(default))
-            .map_err(|err| format!("invalid uri argument for {}: {:?}", name, err))
+            .map_err(|err| format!("invalid uri argument for {name}: {err:?}"))
     }
 }
 

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,3 +1,4 @@
+use crate::{Error, Result};
 use helium_proto::Region as ProtoRegion;
 use serde::{de, Deserialize, Deserializer};
 use std::fmt;
@@ -30,8 +31,7 @@ where
         "IN865" => Region(ProtoRegion::In865),
         unsupported => {
             return Err(de::Error::custom(format!(
-                "unsupported region: {}",
-                unsupported
+                "unsupported region: {unsupported}"
             )))
         }
     };
@@ -66,5 +66,13 @@ impl From<Region> for i32 {
 impl From<&Region> for i32 {
     fn from(region: &Region) -> Self {
         region.0.into()
+    }
+}
+
+impl Region {
+    pub fn from_i32(v: i32) -> Result<Self> {
+        ProtoRegion::from_i32(v)
+            .map(Self)
+            .ok_or_else(|| Error::custom(format!("unsupported region {v}")))
     }
 }

--- a/src/router/dispatcher.rs
+++ b/src/router/dispatcher.rs
@@ -284,11 +284,9 @@ impl Dispatcher {
         logger: &Logger,
     ) {
         let update_height = response.height();
-        if update_height <= self.region_height {
-            warn!(
-                logger,
-                "region returned invalid height {} while at {}", update_height, self.region_height
-            );
+        let region_height = self.region_height;
+        if update_height <= region_height {
+            warn!(logger, "region returned invalid height {update_height} while at {region_height}");
             return;
         }
         match response.region() {

--- a/src/router/dispatcher.rs
+++ b/src/router/dispatcher.rs
@@ -27,6 +27,9 @@ pub enum Message {
     Height {
         response: sync::ResponseSender<Result<HeightResponse>>,
     },
+    Region {
+        response: sync::ResponseSender<Result<Region>>,
+    },
 }
 
 #[derive(Debug)]
@@ -68,6 +71,12 @@ impl MessageSender {
         let _ = self.0.send(Message::Height { response: tx }).await;
         rx.recv().await?
     }
+
+    pub async fn region(&self) -> Result<Region> {
+        let (tx, rx) = sync::response_channel();
+        let _ = self.0.send(Message::Region { response: tx }).await;
+        rx.recv().await?
+    }
 }
 
 pub struct Dispatcher {
@@ -77,6 +86,7 @@ pub struct Dispatcher {
     downlinks: gateway::MessageSender,
     gateways: Vec<KeyedUri>,
     routing_height: u64,
+    region_height: u64,
     default_router: KeyedUri,
     cache_settings: CacheSettings,
     routers: HashMap<RouterKey, RouterEntry>,
@@ -115,6 +125,7 @@ impl Dispatcher {
             gateways,
             routers,
             routing_height: 0,
+            region_height: 0,
             default_router,
             cache_settings,
         })
@@ -129,7 +140,7 @@ impl Dispatcher {
             "uri" => self.default_router.uri.to_string());
 
         loop {
-            let mut gateway = GatewayService::random_new(&self.gateways)?;
+            let gateway = GatewayService::random_new(&self.gateways)?;
             info!(logger, "using gateway";
                 "pubkey" => gateway.uri.pubkey.to_string(),
                 "uri" => gateway.uri.uri.to_string());
@@ -138,10 +149,10 @@ impl Dispatcher {
                     info!(logger, "shutting down");
                     return Ok(())
                 },
-                routing_stream = gateway.routing(self.routing_height) => {
-                    match routing_stream {
-                        Ok(stream) => self.run_with_routing_stream(gateway, stream, shutdown.clone(), &logger).await?,
-                        Err(err) => warn!(logger, "gateway error: {:?}", err)
+                gateway_streams = self.gateway_streams(gateway.clone()) => {
+                    match gateway_streams {
+                        Ok((routing_stream, region_stream)) => self.run_with_gateway_streams(gateway, routing_stream, region_stream, shutdown.clone(), &logger).await?,
+                        Err(err) => warn!(logger, "gateway error: {err:?}")
                     }
                     // Check if trigger happened in run_with_routing_stream
                     if shutdown.is_triggered() {
@@ -156,10 +167,22 @@ impl Dispatcher {
         }
     }
 
-    async fn run_with_routing_stream(
+    async fn gateway_streams(
+        &mut self,
+        gateway: GatewayService,
+    ) -> Result<(service::gateway::Streaming, service::gateway::Streaming)> {
+        let mut routing_gateway = gateway.clone();
+        let routing = routing_gateway.routing(self.routing_height);
+        let mut region_params_gateway = gateway.clone();
+        let region_params = region_params_gateway.region_params(self.keypair.clone());
+        tokio::try_join!(routing, region_params)
+    }
+
+    async fn run_with_gateway_streams(
         &mut self,
         mut gateway: GatewayService,
         mut routing_stream: service::gateway::Streaming,
+        mut region_stream: service::gateway::Streaming,
         shutdown: triggered::Listener,
         logger: &Logger,
     ) -> Result {
@@ -174,11 +197,22 @@ impl Dispatcher {
                 routing = routing_stream.message() => match routing {
                     Ok(Some(response)) => self.handle_routing_update(&mut gateway, &response, &shutdown, logger).await,
                     Ok(None) => {
-                        warn!(logger, "gateway stream closed");
+                        warn!(logger, "gateway routing stream closed");
                         return Ok(());
                     },
                     Err(err) => {
-                        warn!(logger, "gateway stream error: {:?}", err);
+                        warn!(logger, "gateway routing stream error: {:?}", err);
+                        return Ok(())
+                    },
+                },
+                region = region_stream.message() => match region {
+                    Ok(Some(response)) => self.handle_region_update(&response, logger).await,
+                    Ok(None) => {
+                        warn!(logger, "gateway region stream closed");
+                        return Ok(());
+                    },
+                    Err(err) => {
+                        warn!(logger, "gateway region stream error: {:?}", err);
                         return Ok(())
                     },
                 },
@@ -194,8 +228,9 @@ impl Dispatcher {
         for (_, router_entry) in self.routers.drain() {
             router_entry.dispatch.gateway_changed().await;
         }
-        // Reset routing heigth for the next gateway
+        // Reset routing and region heigth for the next gateway
         self.routing_height = 0;
+        self.region_height = 0;
     }
 
     async fn handle_message(
@@ -218,6 +253,7 @@ impl Dispatcher {
                     });
                 response.send(reply, logger)
             }
+            Message::Region { response } => response.send(Ok(self.region), logger),
         }
     }
 
@@ -242,6 +278,30 @@ impl Dispatcher {
         }
     }
 
+    async fn handle_region_update(
+        &mut self,
+        response: &service::gateway::Response,
+        logger: &Logger,
+    ) {
+        let update_height = response.height();
+        if update_height <= self.region_height {
+            warn!(
+                logger,
+                "region returned invalid height {} while at {}", update_height, self.region_height
+            );
+            return;
+        }
+        match response.region() {
+            Ok(region) => {
+                self.region_height = update_height;
+                self.region = region;
+            }
+            Err(err) => {
+                warn!(logger, "error decoding region: {err:?}");
+            }
+        }
+    }
+
     async fn handle_routing_update(
         &mut self,
         gateway: &mut GatewayService,
@@ -253,7 +313,7 @@ impl Dispatcher {
         if update_height <= self.routing_height {
             warn!(
                 logger,
-                "router returned invalid height {:?} while at {:?}",
+                "routing returned invalid height {:?} while at {:?}",
                 update_height,
                 self.routing_height
             );

--- a/src/service/gateway.rs
+++ b/src/service/gateway.rs
@@ -136,7 +136,7 @@ impl GatewayService {
 
     pub async fn region_params(&mut self, keypair: Arc<Keypair>) -> Result<Streaming> {
         let mut req = GatewayRegionParamsUpdateReqV1 {
-            address: self.uri.pubkey.to_vec(),
+            address: keypair.public_key().to_vec(),
             signature: vec![],
         };
         req.signature = req.sign(keypair).await?;

--- a/src/service/gateway.rs
+++ b/src/service/gateway.rs
@@ -1,11 +1,12 @@
-use crate::{service::CONNECT_TIMEOUT, Error, KeyedUri, MsgVerify, Result};
-use helium_crypto::PublicKey;
+use crate::{service::CONNECT_TIMEOUT, Error, KeyedUri, MsgSign, MsgVerify, Region, Result};
+use helium_crypto::{Keypair, PublicKey};
 use helium_proto::{
     gateway_resp_v1,
     services::{self, Channel, Endpoint},
     BlockchainTxnStateChannelCloseV1, BlockchainVarV1, GatewayConfigReqV1, GatewayConfigRespV1,
-    GatewayRespV1, GatewayRoutingReqV1, GatewayScCloseReqV1, GatewayScFollowReqV1,
-    GatewayScFollowStreamedRespV1, GatewayScIsActiveReqV1, GatewayScIsActiveRespV1, Routing,
+    GatewayRegionParamsUpdateReqV1, GatewayRespV1, GatewayRoutingReqV1, GatewayScCloseReqV1,
+    GatewayScFollowReqV1, GatewayScFollowStreamedRespV1, GatewayScIsActiveReqV1,
+    GatewayScIsActiveRespV1, Routing,
 };
 use rand::{rngs::OsRng, seq::SliceRandom};
 use std::{sync::Arc, time::Duration};
@@ -43,10 +44,20 @@ impl Response {
     pub fn routings(&self) -> Result<&[Routing]> {
         match &self.0.msg {
             Some(gateway_resp_v1::Msg::RoutingStreamedResp(routings)) => Ok(&routings.routings),
-            msg => Err(Error::custom(format!(
-                "Unexpected gateway message {:?}",
-                msg
-            ))),
+            msg => Err(Error::custom(
+                format!("Unexpected gateway message {msg:?}",),
+            )),
+        }
+    }
+
+    pub fn region(&self) -> Result<Region> {
+        match &self.0.msg {
+            Some(gateway_resp_v1::Msg::RegionParamsStreamedResp(params)) => {
+                Region::from_i32(params.region)
+            }
+            msg => Err(Error::custom(
+                format!("Unexpected gateway message {msg:?}",),
+            )),
         }
     }
 }
@@ -84,8 +95,7 @@ impl StateChannelFollowService {
             })) => Ok(Some(resp)),
             Ok(None) => Ok(None),
             Ok(msg) => Err(Error::custom(format!(
-                "unexpected gateway response {:?}",
-                msg
+                "unexpected gateway response {msg:?}",
             ))),
             Err(err) => Err(err.into()),
         }
@@ -124,6 +134,20 @@ impl GatewayService {
         })
     }
 
+    pub async fn region_params(&mut self, keypair: Arc<Keypair>) -> Result<Streaming> {
+        let mut req = GatewayRegionParamsUpdateReqV1 {
+            address: self.uri.pubkey.to_vec(),
+            signature: vec![],
+        };
+        req.signature = req.sign(keypair).await?;
+
+        let stream = self.client.region_params_update(req).await?;
+        Ok(Streaming {
+            streaming: stream.into_inner(),
+            verifier: self.uri.pubkey.clone(),
+        })
+    }
+
     pub async fn is_active_sc(
         &mut self,
         id: &[u8],
@@ -150,8 +174,7 @@ impl GatewayService {
                 }
             }
             Some(other) => Err(Error::custom(format!(
-                "invalid is_active response {:?}",
-                other
+                "invalid is_active response {other:?}",
             ))),
             None => Err(Error::custom("empty is_active response")),
         }
@@ -184,10 +207,7 @@ impl GatewayService {
     pub async fn config(&mut self, keys: Vec<String>) -> Result<Vec<BlockchainVarV1>> {
         match self.get_config(keys).await?.msg {
             Some(gateway_resp_v1::Msg::ConfigResp(GatewayConfigRespV1 { result })) => Ok(result),
-            Some(other) => Err(Error::custom(format!(
-                "invalid config response {:?}",
-                other
-            ))),
+            Some(other) => Err(Error::custom(format!("invalid config response {other:?}"))),
             None => Err(Error::custom("empty config response")),
         }
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -147,7 +147,7 @@ impl FromStr for StakingMode {
             "light" => Ok(Self::Light),
             "full" => Ok(Self::Full),
             "dataonly" => Ok(Self::DataOnly),
-            _ => Err(Error::custom(format!("invalid staking mode {}", v))),
+            _ => Err(Error::custom(format!("invalid staking mode {v}"))),
         }
     }
 }
@@ -163,7 +163,7 @@ pub mod log_level {
     {
         let s = String::deserialize(d)?;
         s.parse()
-            .map_err(|_| de::Error::custom(format!("invalid log level \"{}\"", s)))
+            .map_err(|_| de::Error::custom(format!("invalid log level \"{s}\"")))
     }
 }
 
@@ -201,8 +201,7 @@ pub mod log_method {
                         "syslog" => LogMethod::Syslog,
                         unsupported => {
                             return Err(de::Error::custom(format!(
-                                "unsupported log method: \"{}\"",
-                                unsupported
+                                "unsupported log method: \"{unsupported}\""
                             )))
                         }
                     };

--- a/src/traits/msg_sign.rs
+++ b/src/traits/msg_sign.rs
@@ -3,7 +3,7 @@ use futures::TryFutureExt;
 use helium_crypto::{Keypair, Sign};
 use helium_proto::{
     BlockchainStateChannelOfferV1, BlockchainStateChannelPacketV1, BlockchainTxnAddGatewayV1,
-    BlockchainTxnStateChannelCloseV1, Message,
+    BlockchainTxnStateChannelCloseV1, GatewayRegionParamsUpdateReqV1, Message,
 };
 use std::sync::Arc;
 
@@ -31,6 +31,7 @@ macro_rules! impl_msg_sign {
     };
 }
 
+impl_msg_sign!(GatewayRegionParamsUpdateReqV1, signature);
 impl_msg_sign!(BlockchainStateChannelPacketV1, signature);
 impl_msg_sign!(BlockchainStateChannelOfferV1, signature);
 impl_msg_sign!(BlockchainTxnStateChannelCloseV1, signature);

--- a/src/traits/txn_fee.rs
+++ b/src/traits/txn_fee.rs
@@ -159,28 +159,27 @@ trait ToValue<T> {
 
 impl ToValue<bool> for ConfigValue {
     fn to_value(&self) -> Result<bool> {
+        let name = &self.name;
         if self.r#type != "atom" {
-            return Err(Error::custom(format!(
-                "not a boolean variable: {}",
-                self.name
-            )));
+            return Err(Error::custom(format!("not a boolean variable: {name}",)));
         }
         let value = std::str::from_utf8(&self.value)
-            .map_err(|_| Error::custom(format!("not a boolean value: {}", self.name)))?;
+            .map_err(|_| Error::custom(format!("not a boolean value: {name}")))?;
         Ok(value == "true")
     }
 }
 
 impl ToValue<u64> for ConfigValue {
     fn to_value(&self) -> Result<u64> {
+        let name = &self.name;
         if self.r#type != "int" {
-            return Err(Error::custom(format!("not an int variable: {}", self.name)));
+            return Err(Error::custom(format!("not an int variable: {name}")));
         }
         let value = std::str::from_utf8(&self.value)
-            .map_err(|_| Error::custom(format!("not an valid value: {}", self.name)))
+            .map_err(|_| Error::custom(format!("not an valid value: {name}")))
             .and_then(|v| {
                 v.parse::<u64>()
-                    .map_err(|_| Error::custom(format!("not a valid int value: {}", self.name)))
+                    .map_err(|_| Error::custom(format!("not a valid int value: {name}")))
             })?;
         Ok(value)
     }

--- a/src/updater/releases.rs
+++ b/src/updater/releases.rs
@@ -42,7 +42,7 @@ pub fn all(url: String) -> Stream<Release> {
 }
 
 fn fetch_releases(url: String, page: u32) -> Future<((String, u32), Vec<Release>)> {
-    let curl_url = format!("{}?per_page={}&page={}", url, GH_PAGE_SIZE, page);
+    let curl_url = format!("{url}?per_page={GH_PAGE_SIZE}&page={page}");
     curl::get(
         curl_url,
         &["-H", "Accept: application/vnd.github.v3+json"],
@@ -81,8 +81,7 @@ where
         Ok(channel) => Ok(channel),
         Err(_) => {
             return Err(de::Error::custom(format!(
-                "unsupported update channel: \"{}\"",
-                channel_str
+                "unsupported update channel: \"{channel_str}\"",
             )))
         }
     }
@@ -148,7 +147,7 @@ where
     };
     version_str
         .parse()
-        .map_err(|e| de::Error::custom(format!("invalid release format \"{}\": {}", s, e)))
+        .map_err(|e| de::Error::custom(format!("invalid release format \"{s}\": {e}")))
 }
 
 impl Release {
@@ -174,7 +173,8 @@ impl Release {
     }
 
     pub fn asset_for_platform(&self, platform: &str) -> Option<&ReleaseAsset> {
-        let package_name = format!("helium-gateway-v{}-{}", self.version, platform);
+        let version = &self.version;
+        let package_name = format!("helium-gateway-v{version}-{platform}");
         self.asset_named(&package_name)
     }
 


### PR DESCRIPTION
This sets the gateway to follow the asserted lorawan region by following the regions through the associated gateway-service. 

The helium-gateway cli adds a new `region` info argument which will fetch the currently set region for the gateway. 

**Note**

The region setting in `settings.toml` will be used as the initial setting until a region update is received from the chain. This means that if the hotspot is never location asserted on chain the region will remain set to the settings.toml value. 

The info region command will return the default setting if no chain setting is asserted or found