### PR TITLE
Improve Error Msgs

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,7 +1,7 @@
 use super::{
     connect_uri, ConfigReq, ConfigValue, HeightReq, HeightRes, PubkeyReq, RegionReq, SignReq,
 };
-use crate::{error::ServiceError, PublicKey, Region, Result};
+use crate::{error::Error, PublicKey, Region, Result};
 use helium_proto::services::local::Client;
 use std::convert::TryFrom;
 use tonic::transport::{Channel, Endpoint};
@@ -16,7 +16,7 @@ impl LocalClient {
         let endpoint = Endpoint::from_shared(uri).unwrap();
         let client = Client::connect(endpoint)
             .await
-            .map_err(ServiceError::LocalClientConnect)?;
+            .map_err(Error::local_client_connect)?;
         Ok(Self { client })
     }
 

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,7 +1,7 @@
 use super::{
     connect_uri, ConfigReq, ConfigValue, HeightReq, HeightRes, PubkeyReq, RegionReq, SignReq,
 };
-use crate::{PublicKey, Region, Result};
+use crate::{error::ServiceError, PublicKey, Region, Result};
 use helium_proto::services::local::Client;
 use std::convert::TryFrom;
 use tonic::transport::{Channel, Endpoint};
@@ -14,7 +14,9 @@ impl LocalClient {
     pub async fn new(port: u16) -> Result<Self> {
         let uri = connect_uri(port);
         let endpoint = Endpoint::from_shared(uri).unwrap();
-        let client = Client::connect(endpoint).await?;
+        let client = Client::connect(endpoint)
+            .await
+            .map_err(ServiceError::LocalClientConnect)?;
         Ok(Self { client })
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -206,6 +206,10 @@ impl Error {
         Error::Service(ServiceError::NoService)
     }
 
+    pub fn local_client_connect(e: helium_proto::services::Error) -> Error {
+        Error::Service(ServiceError::LocalClientConnect(e))
+    }
+
     pub fn gateway_service_check(block_age: u64, max_age: u64) -> Error {
         Error::Service(ServiceError::Check { block_age, max_age })
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,7 +70,7 @@ pub enum ServiceError {
     NoService,
     #[error("block age {block_age}s > {max_age}s")]
     Check { block_age: u64, max_age: u64 },
-    #[error("Unable to connect to local client. Check the `helium_gateway server` is running.")]
+    #[error("Unable to connect to local server. Check that `helium_gateway` is running.")]
     LocalClientConnect(helium_proto::services::Error),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,7 @@ pub enum Error {
     Encode(#[from] EncodeError),
     #[error("decode error")]
     Decode(#[from] DecodeError),
-    #[error("service error: {0}")]
+    #[error("service error {0}")]
     Service(#[from] ServiceError),
     #[error("state channel error")]
     StateChannel(#[from] Box<StateChannelError>),
@@ -58,9 +58,9 @@ pub enum DecodeError {
 
 #[derive(Error, Debug)]
 pub enum ServiceError {
-    #[error("service: {0:?}")]
+    #[error("service {0:?}")]
     Service(#[from] helium_proto::services::Error),
-    #[error("rpc: {0:?}")]
+    #[error("rpc {0:?}")]
     Rpc(#[from] tonic::Status),
     #[error("stream closed")]
     Stream,

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,6 +70,8 @@ pub enum ServiceError {
     NoService,
     #[error("block age {block_age}s > {max_age}s")]
     Check { block_age: u64, max_age: u64 },
+    #[error("Unable to connect to local client. Check the `helium_gateway server` is running.")]
+    LocalClientConnect(helium_proto::services::Error),
 }
 
 #[allow(clippy::large_enum_variant)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,7 @@ pub enum Error {
     Encode(#[from] EncodeError),
     #[error("decode error")]
     Decode(#[from] DecodeError),
-    #[error("service error {0}")]
+    #[error("service error: {0}")]
     Service(#[from] ServiceError),
     #[error("state channel error")]
     StateChannel(#[from] Box<StateChannelError>),
@@ -58,9 +58,9 @@ pub enum DecodeError {
 
 #[derive(Error, Debug)]
 pub enum ServiceError {
-    #[error("service {0}")]
+    #[error("service: {0:?}")]
     Service(#[from] helium_proto::services::Error),
-    #[error("rpc {0}")]
+    #[error("rpc: {0:?}")]
     Rpc(#[from] tonic::Status),
     #[error("stream closed")]
     Stream,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use gateway_rs::{
     error::Result,
     settings::{LogMethod, Settings},
 };
-use slog::{self, debug, error,  o, Drain, Logger};
+use slog::{self, debug, error, o, Drain, Logger};
 use std::{io, path::PathBuf};
 use structopt::StructOpt;
 use tokio::{io::AsyncReadExt, signal, time::Duration};

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,13 +103,12 @@ pub fn main() -> Result {
             }
             shutdown_trigger.trigger()
         });
-        run(cli, settings, &shutdown_listener, run_logger).await
+        run(cli, settings, &shutdown_listener, run_logger.clone()).await
     });
     runtime.shutdown_timeout(Duration::from_secs(0));
 
     if let Err(e) = &res {
-        let error_logger = slog_scope::logger().new(o!());
-        error!(&error_logger, "{e}");
+        error!(&run_logger, "{e}");
     };
     drop(scope_guard);
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use gateway_rs::{
     error::Result,
     settings::{LogMethod, Settings},
 };
-use slog::{self, debug, o, Drain, Logger};
+use slog::{self, debug, error,  o, Drain, Logger};
 use std::{io, path::PathBuf};
 use structopt::StructOpt;
 use tokio::{io::AsyncReadExt, signal, time::Duration};
@@ -107,8 +107,12 @@ pub fn main() -> Result {
     });
     runtime.shutdown_timeout(Duration::from_secs(0));
 
+    if let Err(e) = &res {
+        let error_logger = slog_scope::logger().new(o!());
+        error!(&error_logger, "{e}");
+    };
     drop(scope_guard);
-    res
+    Ok(())
 }
 
 pub async fn run(


### PR DESCRIPTION
#203 #202 are similar tickets where the user was not running `helium_gateway server` before trying to use the info command.

The cited error message is a little cryptic for a non-dev:
```
Error: Service(Service(tonic::transport::Error(Transport, hyper::Error(Connect, ConnectError("tcp connect error", Os { code: 146, kind: ConnectionRefused, message: "Connection refused" })))))
```

The changes in `main.rs` use the logger to output the error before shutting down, thus using the custom display in the error's attribute:
```
Feb 28 19:14:36.222 ERRO service error service transport error
```

Adding colons and debug to the lowest level error message yields somethiong similar to the original error message,  but a little nicer:

```
Feb 28 19:18:47.945 ERRO service error: service: tonic::transport::Error(Transport, hyper::Error(Connect, ConnectError("tcp connect error", Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))
```

Mapping the transport error during `LocalClient::new` provides an explicit hint to the user:
```
Feb 28 19:15:30.602 ERRO service error: Unable to connect to local client. Check the `helium_gateway server` is running.
```