### PR TITLE
Remove toolchain file

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly


### PR DESCRIPTION
We no longer need nightly features when compiling with rustc >= 1.59 