### PR TITLE
Track state channel diffs 

### DIFF
--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -1,5 +1,6 @@
 use crate::{
-    api::LocalClient, cmd::*, settings::StakingMode, PublicKey, Result, Settings, TxnEnvelope,
+    api::LocalClient, cmd::*, settings::StakingMode, Base64, PublicKey, Result, Settings,
+    TxnEnvelope,
 };
 use helium_proto::BlockchainTxnAddGatewayV1;
 use serde_json::json;
@@ -40,7 +41,7 @@ fn print_txn(mode: &StakingMode, txn: &BlockchainTxnAddGatewayV1) -> Result {
         "owner": PublicKey::from_bytes(&txn.owner)?.to_string(),
         "fee": txn.fee,
         "staking fee": txn.staking_fee,
-        "txn": base64::encode_config(&txn.in_envelope_vec()?, base64::STANDARD),
+        "txn": txn.in_envelope_vec()?.to_b64(),
     });
     print_json(&table)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,7 +84,7 @@ pub enum StateChannelError {
     #[error("inactive state channel")]
     Inactive,
     #[error("state channel not found")]
-    NotFound,
+    NotFound { sc_id: Vec<u8> },
     #[error("invalid owner for state channel")]
     InvalidOwner,
     #[error("state channel summary error")]
@@ -178,8 +178,9 @@ impl StateChannelError {
         Error::StateChannel(Box::new(Self::Inactive))
     }
 
-    pub fn not_found() -> Error {
-        Error::StateChannel(Box::new(Self::NotFound))
+    pub fn not_found(sc_id: &[u8]) -> Error {
+        let sc_id = sc_id.to_vec();
+        Error::StateChannel(Box::new(Self::NotFound { sc_id }))
     }
 
     pub fn ignored(sc: state_channel::StateChannel) -> Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,6 +83,8 @@ pub enum StateChannelError {
     Ignored { sc: state_channel::StateChannel },
     #[error("inactive state channel")]
     Inactive,
+    #[error("state channel not found")]
+    NotFound,
     #[error("invalid owner for state channel")]
     InvalidOwner,
     #[error("state channel summary error")]
@@ -174,6 +176,10 @@ impl StateChannelError {
 
     pub fn inactive() -> Error {
         Error::StateChannel(Box::new(Self::Inactive))
+    }
+
+    pub fn not_found() -> Error {
+        Error::StateChannel(Box::new(Self::NotFound))
     }
 
     pub fn ignored(sc: state_channel::StateChannel) -> Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,8 +34,3 @@ pub type Future<T> = Pin<Box<dyn StdFuture<Output = Result<T>> + Send>>;
 
 /// A type alias for `Stream` that may result in `crate::error::Error`
 pub type Stream<T> = Pin<Box<dyn StdStream<Item = Result<T>> + Send>>;
-
-/// Convert a slice of bytes to a base64 url encoded string
-pub fn hash_str(hash: &[u8]) -> String {
-    base64::encode_config(hash, base64::URL_SAFE_NO_PAD)
-}

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,4 +1,4 @@
-use crate::{error::DecodeError, hash_str, Error, Result};
+use crate::{error::DecodeError, Error, Result};
 use helium_proto::{
     packet::PacketType, routing_information::Data as RoutingData, BlockchainStateChannelResponseV1,
     Eui, RoutingInformation,
@@ -156,10 +156,6 @@ impl Packet {
 
     pub fn hash(&self) -> Vec<u8> {
         Sha256::digest(&self.0.payload).to_vec()
-    }
-
-    pub fn hash_str(&self) -> String {
-        hash_str(&self.hash())
     }
 
     pub fn dc_payload(&self) -> u64 {

--- a/src/router/client.rs
+++ b/src/router/client.rs
@@ -350,6 +350,11 @@ impl RouterClient {
                             self.store
                                 .store_conflicting_state_channel(sc, conflicts_with)
                         }
+                        StateChannelError::NotFound { sc_id } => {
+                            warn!(logger, "ignoring purchase with no local state channel";
+                                    "sc_id" => hash_str(&sc_id));
+                            Ok(())
+                        }
                         err => {
                             info!(logger, "ignoring purchase: {err:?}");
                             Ok(())

--- a/src/service/gateway.rs
+++ b/src/service/gateway.rs
@@ -102,7 +102,7 @@ impl StateChannelFollowService {
             Ok(msg) => Err(Error::custom(format!(
                 "unexpected gateway response {msg:?}",
             ))),
-            Err(err) => Err(err.into()),
+            Err(err) => Err(err),
         }
     }
 }

--- a/src/service/gateway.rs
+++ b/src/service/gateway.rs
@@ -15,6 +15,7 @@ use tokio_stream::wrappers::ReceiverStream;
 
 type GatewayClient = services::gateway::Client<Channel>;
 
+#[derive(Debug)]
 pub struct Streaming {
     streaming: tonic::Streaming<GatewayRespV1>,
     verifier: Arc<PublicKey>,
@@ -65,16 +66,20 @@ impl Response {
 #[derive(Debug)]
 pub struct StateChannelFollowService {
     tx: mpsc::Sender<GatewayScFollowReqV1>,
-    rx: tonic::Streaming<GatewayRespV1>,
+    rx: Streaming,
 }
 
 impl StateChannelFollowService {
-    pub async fn new(mut client: GatewayClient) -> Result<Self> {
+    pub async fn new(mut client: GatewayClient, verifier: Arc<PublicKey>) -> Result<Self> {
         let (tx, client_rx) = mpsc::channel(3);
-        let rx = client
+        let streaming = client
             .follow_sc(ReceiverStream::new(client_rx))
             .await?
             .into_inner();
+        let rx = Streaming {
+            streaming,
+            verifier,
+        };
         Ok(Self { tx, rx })
     }
 
@@ -89,10 +94,10 @@ impl StateChannelFollowService {
     pub async fn message(&mut self) -> Result<Option<GatewayScFollowStreamedRespV1>> {
         use helium_proto::gateway_resp_v1::Msg;
         match self.rx.message().await {
-            Ok(Some(GatewayRespV1 {
+            Ok(Some(Response(GatewayRespV1 {
                 msg: Some(Msg::FollowStreamedResp(resp)),
                 ..
-            })) => Ok(Some(resp)),
+            }))) => Ok(Some(resp)),
             Ok(None) => Ok(None),
             Ok(msg) => Err(Error::custom(format!(
                 "unexpected gateway response {msg:?}",
@@ -181,7 +186,7 @@ impl GatewayService {
     }
 
     pub async fn follow_sc(&mut self) -> Result<StateChannelFollowService> {
-        StateChannelFollowService::new(self.client.clone()).await
+        StateChannelFollowService::new(self.client.clone(), self.uri.pubkey.clone()).await
     }
 
     pub async fn close_sc(&mut self, close_txn: BlockchainTxnStateChannelCloseV1) -> Result {

--- a/src/state_channel/channel.rs
+++ b/src/state_channel/channel.rs
@@ -245,7 +245,7 @@ pub async fn check_active_diff(
         // No entry is not good for a diff since there's no state channel to
         // clone
         {
-            Err(StateChannelError::not_found())
+            Err(StateChannelError::not_found(&diff.id))
         }
         Some(entry) => match entry {
             // If the entry is ignored return an error

--- a/src/state_channel/channel.rs
+++ b/src/state_channel/channel.rs
@@ -1,6 +1,5 @@
 use crate::{
     error::{DecodeError, StateChannelError, StateChannelSummaryError},
-    hash_str,
     router::{store::StateChannelEntry, QuePacket, RouterStore},
     service::gateway::GatewayService,
     Error, MsgVerify, Result,
@@ -169,16 +168,8 @@ impl StateChannel {
         &self.sc.owner
     }
 
-    pub fn id_str(&self) -> String {
-        hash_str(&self.sc.id)
-    }
-
     pub fn amount(&self) -> u64 {
         self.sc.credits
-    }
-
-    pub fn hash_str(&self) -> String {
-        hash_str(&self.hash())
     }
 
     pub fn hash(&self) -> Vec<u8> {

--- a/src/state_channel/message.rs
+++ b/src/state_channel/message.rs
@@ -26,7 +26,12 @@ impl StateChannelMessage {
         Ok(StateChannelMessage::from(packet))
     }
 
-    pub async fn offer(packet: Packet, keypair: Arc<Keypair>, region: Region) -> Result<Self> {
+    pub async fn offer(
+        packet: Packet,
+        keypair: Arc<Keypair>,
+        region: Region,
+        req_diff: bool,
+    ) -> Result<Self> {
         let frame = Packet::parse_frame(lorawan::Direction::Uplink, packet.payload())?;
         let mut offer = BlockchainStateChannelOfferV1 {
             packet_hash: packet.hash(),
@@ -36,7 +41,7 @@ impl StateChannelMessage {
             region: region.into(),
             routing: Packet::routing_information(&frame)?,
             signature: vec![],
-            req_diff: false,
+            req_diff,
         };
         offer.signature = offer.sign(keypair).await?;
         Ok(Self::from(offer))

--- a/src/state_channel/mod.rs
+++ b/src/state_channel/mod.rs
@@ -1,5 +1,7 @@
 mod channel;
 mod message;
 
-pub use channel::{check_active, StateChannel, StateChannelCausality, StateChannelValidation};
+pub use channel::{
+    check_active, check_active_diff, StateChannel, StateChannelCausality, StateChannelValidation,
+};
 pub use message::StateChannelMessage;

--- a/src/traits/base64.rs
+++ b/src/traits/base64.rs
@@ -1,0 +1,18 @@
+pub trait Base64 {
+    fn to_b64url(&self) -> String
+    where
+        Self: AsRef<[u8]>,
+    {
+        base64::encode_config(self.as_ref(), base64::URL_SAFE_NO_PAD)
+    }
+
+    fn to_b64(&self) -> String
+    where
+        Self: AsRef<[u8]>,
+    {
+        base64::encode_config(self.as_ref(), base64::STANDARD)
+    }
+}
+
+impl Base64 for &[u8] {}
+impl Base64 for Vec<u8> {}

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,8 +1,10 @@
+mod base64;
 mod msg_sign;
 mod msg_verify;
 mod txn_envelope;
 mod txn_fee;
 
+pub use self::base64::Base64;
 pub use msg_sign::MsgSign;
 pub use msg_verify::MsgVerify;
 pub use txn_envelope::TxnEnvelope;


### PR DESCRIPTION
* Track sc_diff purchases returned by router in the router client.  This distinguishes between the first offer to request a full state channel and subsequent offers which only request a sc_diff. 
 
* Use a Base64 trait to capture base64url and base64 conversions. 