### PR TITLE
Allow for onboarding_key in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#05460b28dc49747b863310c03a3ddf13db3c01df"
+source = "git+https://github.com/helium/proto?branch=master#fd34a2d3e0187211f9a3d1a5caf32c340a07b19b"
 dependencies = [
  "bytes",
  "prost",

--- a/config/default.toml
+++ b/config/default.toml
@@ -16,6 +16,7 @@
 keypair = "/etc/helium_gateway/gateway_key.bin"
 ## ECC608 based
 # keypair = "ecc://i2c-1:96&slot=0"
+# onboarding = "ecc://i2c-1:96&slot=15"
 listen = "127.0.0.1:1680"
 api = 4467
 region = "US915"

--- a/config/default.toml
+++ b/config/default.toml
@@ -15,8 +15,8 @@
 ## File: 
 keypair = "/etc/helium_gateway/gateway_key.bin"
 ## ECC608 based
-# keypair = "ecc://i2c-1:96&slot=0"
-# onboarding = "ecc://i2c-1:96&slot=15"
+# keypair = "ecc://i2c-1:96?slot=0"
+# onboarding = "ecc://i2c-1:96?slot=15"
 listen = "127.0.0.1:1680"
 api = 4467
 region = "US915"

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -21,10 +21,12 @@ impl LocalClient {
         Ok(Self { client })
     }
 
-    pub async fn pubkey(&mut self) -> Result<PublicKey> {
-        let response = self.client.pubkey(PubkeyReq {}).await?;
-        let public_key = PublicKey::try_from(response.into_inner().address)?;
-        Ok(public_key)
+    pub async fn pubkey(&mut self) -> Result<(PublicKey, PublicKey)> {
+        let response = self.client.pubkey(PubkeyReq {}).await?.into_inner();
+
+        let public_key = PublicKey::try_from(response.address)?;
+        let onboarding_key = PublicKey::try_from(response.onboarding_address)?;
+        Ok((public_key, onboarding_key))
     }
 
     pub async fn sign(&mut self, data: &[u8]) -> Result<Vec<u8>> {

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -19,16 +19,18 @@ pub type ApiResult<T> = std::result::Result<Response<T>, Status>;
 pub struct LocalServer {
     dispatcher: dispatcher::MessageSender,
     keypair: Arc<Keypair>,
+    onboarding_key: PublicKey,
     listen_port: u16,
 }
 
 impl LocalServer {
-    pub fn new(dispatcher: dispatcher::MessageSender, settings: &Settings) -> Self {
-        Self {
+    pub fn new(dispatcher: dispatcher::MessageSender, settings: &Settings) -> Result<Self> {
+        Ok(Self {
             keypair: settings.keypair.clone(),
+            onboarding_key: settings.onboarding_key()?,
             listen_port: settings.api,
             dispatcher,
-        }
+        })
     }
 
     pub async fn run(self, shutdown: triggered::Listener, logger: &Logger) -> Result {
@@ -50,7 +52,7 @@ impl LocalServer {
         let reply = self
             .dispatcher
             .config(&keys)
-            .map_err(|_err| Status::internal("Failed to get config"))
+            .map_err(|err| Status::internal(format!("{err}")))
             .await?;
         let values = reply.into_iter().map(ConfigValue::from).collect();
         Ok(values)
@@ -62,6 +64,7 @@ impl Api for LocalServer {
     async fn pubkey(&self, _request: Request<PubkeyReq>) -> ApiResult<PubkeyRes> {
         let reply = PubkeyRes {
             address: self.keypair.public_key().to_vec(),
+            onboarding_address: self.onboarding_key.to_vec(),
         };
         Ok(Response::new(reply))
     }
@@ -148,7 +151,7 @@ impl Api for LocalServer {
         let reply = self
             .dispatcher
             .height()
-            .map_err(|_err| Status::internal("Failed to get config"))
+            .map_err(|err| Status::internal(format!("{err}")))
             .await?;
         Ok(Response::new(HeightRes {
             height: reply.height,

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -27,7 +27,7 @@ impl LocalServer {
     pub fn new(dispatcher: dispatcher::MessageSender, settings: &Settings) -> Result<Self> {
         Ok(Self {
             keypair: settings.keypair.clone(),
-            onboarding_key: settings.onboarding_key()?,
+            onboarding_key: settings.onboarding_key(),
             listen_port: settings.api,
             dispatcher,
         })

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -138,12 +138,12 @@ impl InfoCache {
         Ok(public_keys)
     }
 
-    async fn onboarding_key(&mut self) -> Result<PublicKey> {
+    async fn public_key(&mut self) -> Result<PublicKey> {
         let (public_key, _) = self._public_keys().await?;
         Ok(public_key)
     }
 
-    async fn public_key(&mut self) -> Result<PublicKey> {
+    async fn onboarding_key(&mut self) -> Result<PublicKey> {
         let (_, onboarding_key) = self._public_keys().await?;
         Ok(onboarding_key)
     }

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -17,6 +17,7 @@ use structopt::StructOpt;
 pub enum InfoKey {
     Fw,
     Key,
+    OnboardingKey,
     Name,
     Gateway,
     Region,
@@ -34,7 +35,7 @@ pub struct Cmd {
         long,
         short,
         multiple = false,
-        default_value = "fw,key,name,region,gateway"
+        default_value = "fw,key,onboarding,name,region,gateway"
     )]
     pub keys: InfoKeys,
 }
@@ -52,6 +53,7 @@ impl Cmd {
 
 const INFO_FW: &str = "fw";
 const INFO_KEY: &str = "key";
+const INFO_ONBOARDING_KEY: &str = "onboarding";
 const INFO_NAME: &str = "name";
 const INFO_GATEWAY: &str = "gateway";
 const INFO_REGION: &str = "region";
@@ -61,6 +63,7 @@ impl fmt::Display for InfoKey {
         let s = match self {
             Self::Fw => INFO_FW,
             Self::Key => INFO_KEY,
+            Self::OnboardingKey => INFO_ONBOARDING_KEY,
             Self::Name => INFO_NAME,
             Self::Gateway => INFO_GATEWAY,
             Self::Region => INFO_REGION,
@@ -84,6 +87,7 @@ impl FromStr for InfoKey {
         match s {
             INFO_FW => Ok(Self::Fw),
             INFO_KEY => Ok(Self::Key),
+            INFO_ONBOARDING_KEY => Ok(Self::OnboardingKey),
             INFO_NAME => Ok(Self::Name),
             INFO_GATEWAY => Ok(Self::Gateway),
             INFO_REGION => Ok(Self::Region),
@@ -108,7 +112,7 @@ impl std::str::FromStr for InfoKeys {
 struct InfoCache {
     platform: String,
     port: u16,
-    public_key: Option<PublicKey>,
+    public_keys: Option<(PublicKey, PublicKey)>,
     height: Option<HeightRes>,
     region: Option<Region>,
 }
@@ -118,20 +122,30 @@ impl InfoCache {
         Self {
             platform,
             port,
-            public_key: None,
+            public_keys: None,
             height: None,
             region: None,
         }
     }
 
-    async fn public_key(&mut self) -> Result<PublicKey> {
-        if let Some(public_key) = &self.public_key {
-            return Ok(public_key.clone());
+    async fn _public_keys(&mut self) -> Result<(PublicKey, PublicKey)> {
+        if let Some(public_keys) = &self.public_keys {
+            return Ok(public_keys.clone());
         }
         let mut client = LocalClient::new(self.port).await?;
-        let public_key = client.pubkey().await?;
-        self.public_key = Some(public_key.clone());
+        let public_keys = client.pubkey().await?;
+        self.public_keys = Some(public_keys.clone());
+        Ok(public_keys)
+    }
+
+    async fn onboarding_key(&mut self) -> Result<PublicKey> {
+        let (public_key, _) = self._public_keys().await?;
         Ok(public_key)
+    }
+
+    async fn public_key(&mut self) -> Result<PublicKey> {
+        let (_, onboarding_key) = self._public_keys().await?;
+        Ok(onboarding_key)
     }
 
     async fn _height(&mut self) -> Result<HeightRes> {
@@ -183,6 +197,9 @@ impl InfoKey {
             }
             Self::Key => {
                 json!(cache.public_key().await?.to_string())
+            }
+            Self::OnboardingKey => {
+                json!(cache.onboarding_key().await?.to_string())
             }
             Self::Name => {
                 let public_key = cache.public_key().await?.to_string();

--- a/src/cmd/key.rs
+++ b/src/cmd/key.rs
@@ -25,7 +25,7 @@ impl Cmd {
 impl Info {
     pub async fn run(&self, settings: Settings) -> Result {
         let cmd = info::Cmd {
-            keys: InfoKeys(vec![InfoKey::Name, InfoKey::Key]),
+            keys: InfoKeys(vec![InfoKey::Name, InfoKey::Key, InfoKey::OnboardingKey]),
         };
         cmd.run(settings).await
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,7 @@ pub enum Error {
     Encode(#[from] EncodeError),
     #[error("decode error")]
     Decode(#[from] DecodeError),
-    #[error("service error {0}")]
+    #[error("service error: {0}")]
     Service(#[from] ServiceError),
     #[error("state channel error")]
     StateChannel(#[from] Box<StateChannelError>),
@@ -38,6 +38,8 @@ pub enum EncodeError {
 pub enum DecodeError {
     #[error("uri decode")]
     Uri(#[from] http::uri::InvalidUri),
+    #[error("keypair uri: {0}")]
+    KeypairUri(String),
     #[error("json decode")]
     Json(#[from] serde_json::Error),
     #[error("base64 decode")]
@@ -161,6 +163,10 @@ impl DecodeError {
 
     pub fn prost_decode(msg: &'static str) -> Error {
         Error::Decode(prost::DecodeError::new(msg).into())
+    }
+
+    pub fn keypair_uri<T: ToString>(msg: T) -> Error {
+        Error::Decode(DecodeError::KeypairUri(msg.to_string()))
     }
 }
 

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -21,58 +21,25 @@ pub fn save_to_file(keypair: &Keypair, path: &str) -> io::Result<()> {
     Ok(())
 }
 
-macro_rules! de_error {
+macro_rules! uri_error {
     ($format:expr) => {
-        de::Error::custom($format)
+        error::DecodeError::keypair_uri(format!($format))
     };
     ($format:expr, $( $arg:expr ),+ ) => {
-        de::Error::custom(format!($format, $( $arg ),+))
+        error::DecodeError::keypair_uri(format!($format, $( $arg ),+))
     };
 }
 
-struct KeypairArgs(HashMap<String, String>);
-
-impl KeypairArgs {
-    pub(crate) fn from_uri(url: &Uri) -> std::result::Result<Self, String> {
-        let args = url
-            .query()
-            .map_or_else(
-                || Ok(HashMap::new()),
-                serde_urlencoded::from_str::<HashMap<String, String>>,
-            )
-            .map_err(|err| format!("invalid keypair url \"{url}\": {err:?}"))?;
-        Ok(Self(args))
-    }
-
-    pub fn get<T>(&self, name: &str, default: T) -> std::result::Result<T, String>
-    where
-        T: std::str::FromStr,
-        <T as std::str::FromStr>::Err: std::fmt::Debug,
-    {
-        self.0
-            .get(name)
-            .map(|s| s.parse::<T>())
-            .unwrap_or(Ok(default))
-            .map_err(|err| format!("invalid uri argument for {name}: {err:?}"))
-    }
-}
-
-pub fn deserialize<'de, D>(d: D) -> std::result::Result<Arc<Keypair>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s = String::deserialize(d)?;
-    let url: Uri = s
+pub fn from_str(str: &str) -> Result<Arc<Keypair>> {
+    let url: Uri = str
         .parse()
-        .map_err(|err| de_error!("invalid keypair url \"{}\": {:?}", s, err))?;
+        .map_err(|err| uri_error!("invalid keypair url \"{str}\": {err:?}"))?;
     match url.scheme_str() {
         Some("file") | None => match load_from_file(url.path()) {
             Ok(k) => Ok(Arc::new(k)),
             Err(Error::IO(io_error)) if io_error.kind() == std::io::ErrorKind::NotFound => {
-                let args = KeypairArgs::from_uri(&url).map_err(de::Error::custom)?;
-                let network = args
-                    .get::<Network>("network", Network::MainNet)
-                    .map_err(de::Error::custom)?;
+                let args = KeypairArgs::from_uri(&url)?;
+                let network = args.get::<Network>("network", Network::MainNet)?;
                 let new_key = Keypair::generate(
                     KeyTag {
                         network,
@@ -81,46 +48,76 @@ where
                     &mut OsRng,
                 );
                 save_to_file(&new_key, url.path()).map_err(|err| {
-                    de_error!("unable to save key file \"{}\": {:?}", url.path(), err)
+                    uri_error!("unable to save key file \"{}\": {err:?}", url.path())
                 })?;
                 Ok(Arc::new(new_key))
             }
-            Err(err) => Err(de_error!(
-                "unable to load key file \"{}\": {:?}",
-                url.path(),
-                err
+            Err(err) => Err(uri_error!(
+                "unable to load key file \"{}\": {err:?}",
+                url.path()
             )),
         },
         Some("ecc") => {
-            let args = KeypairArgs::from_uri(&url).map_err(de::Error::custom)?;
+            let args = KeypairArgs::from_uri(&url).map_err(error::DecodeError::keypair_uri)?;
 
             let bus_address = url.port_u16().unwrap_or(96);
-            let slot = args.get::<u8>("slot", 0).map_err(de::Error::custom)?;
-            let network = args
-                .get("network", Network::MainNet)
-                .map_err(de::Error::custom)?;
+            let slot = args.get::<u8>("slot", 0)?;
+            let network = args.get("network", Network::MainNet)?;
             let path = url
                 .host()
                 .map(|dev| Path::new("/dev").join(dev))
-                .ok_or_else(|| de_error!("missing ecc device path"))?;
+                .ok_or_else(|| uri_error!("missing ecc device path"))?;
             let keypair = ecc608::init(&path.to_string_lossy(), bus_address)
                 .map_err(|err| {
-                    de_error!(
-                        "could not initialize ecc \"{}:{}\": {:?}",
-                        path.to_string_lossy(),
-                        bus_address,
-                        err
+                    uri_error!(
+                        "could not initialize ecc \"{}:{bus_address}\": {err:?}",
+                        path.to_string_lossy()
                     )
                 })
                 .and_then(|_| {
                     ecc608::Keypair::from_slot(network, slot).map_err(|err| {
-                        de_error!("could not load ecc keypair in slot {}: {:?}", slot, err)
+                        uri_error!("could not load ecc keypair in slot {slot}: {err:?}")
                     })
                 })?;
             Ok(Arc::new(keypair.into()))
         }
-        Some(unknown) => Err(de_error!("unkown keypair scheme: \"{}\"", unknown)),
+        Some(unknown) => Err(uri_error!("unkown keypair scheme: \"{unknown}\"")),
     }
+}
+
+struct KeypairArgs(HashMap<String, String>);
+
+impl KeypairArgs {
+    pub(crate) fn from_uri(url: &Uri) -> Result<Self> {
+        let args = url
+            .query()
+            .map_or_else(
+                || Ok(HashMap::new()),
+                serde_urlencoded::from_str::<HashMap<String, String>>,
+            )
+            .map_err(|err| uri_error!("invalid keypair url \"{url}\": {err:?}"))?;
+        Ok(Self(args))
+    }
+
+    pub fn get<T>(&self, name: &str, default: T) -> Result<T>
+    where
+        T: std::str::FromStr,
+        <T as std::str::FromStr>::Err: std::fmt::Debug,
+    {
+        self.0
+            .get(name)
+            .map(|s| s.parse::<T>())
+            .unwrap_or(Ok(default))
+            .map_err(|err| uri_error!("invalid uri argument for {name}: {err:?}"))
+    }
+}
+
+pub fn deserialize<'de, D>(d: D) -> std::result::Result<Arc<Keypair>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s = String::deserialize(d)?;
+    from_str(&s).map_err(|err| de::Error::custom(err.to_string()))
 }
 
 #[cfg(test)]

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -85,6 +85,7 @@ pub fn from_str(str: &str) -> Result<Arc<Keypair>> {
     }
 }
 
+#[derive(Debug)]
 struct KeypairArgs(HashMap<String, String>);
 
 impl KeypairArgs {
@@ -126,10 +127,10 @@ mod tests {
 
     #[test]
     fn keypair_args() {
-        let args =
-            KeypairArgs::from_uri(&Uri::from_static("ecc://i2c-1:96?slot=0&network=testnet"))
-                .expect("keypair args");
-        assert_eq!(0, args.get::<u8>("slot", 22).expect("slot"));
+        let uri = &Uri::from_static("ecc://i2c-1:196?slot=22&network=testnet");
+        let args = KeypairArgs::from_uri(&uri).expect("keypair args");
+        assert_eq!(22, args.get::<u8>("slot", 22).expect("slot"));
+        assert_eq!(196, uri.port_u16().expect("uri port"));
         assert_eq!(
             Network::TestNet,
             args.get::<Network>("network", Network::MainNet)

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,7 +11,7 @@ pub async fn run(shutdown: &triggered::Listener, settings: &Settings, logger: &L
     let mut dispatcher = Dispatcher::new(dispatcher_rx, gateway_tx, settings)?;
     let mut gateway = gateway::Gateway::new(dispatcher_tx.clone(), gateway_rx, settings).await?;
     let updater = Updater::new(settings)?;
-    let api = LocalServer::new(dispatcher_tx, settings);
+    let api = LocalServer::new(dispatcher_tx, settings)?;
     info!(logger,
         "starting server";
         "version" => settings::version().to_string(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -123,7 +123,7 @@ impl Settings {
     /// Returns the onboarding key for this gateway. The onboarding key is
     /// determined by the onboarding setting. If the onbaording setting is not
     /// present or there is any error retrievign the onboarding key from the
-    /// confignred settune the public key of the gateawy is returned.
+    /// confignred setting the public key of the gateawy is returned.
     pub fn onboarding_key(&self) -> PublicKey {
         self.onboarding.as_ref().map_or_else(
             || self.keypair.public_key().to_owned(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -120,12 +120,19 @@ impl Settings {
         &self.router[&self.update.channel.to_string()]
     }
 
-    pub fn onboarding_key(&self) -> Result<PublicKey> {
-        if let Some(str) = self.onboarding.as_ref() {
-            keypair::from_str(str).map(|keypair| keypair.public_key().to_owned())
-        } else {
-            Ok(self.keypair.public_key().to_owned())
-        }
+    /// Returns the onboarding key for this gateway. The onboarding key is
+    /// determined by the onboarding setting. If the onbaording setting is not
+    /// present or there is any error retrievign the onboarding key from the
+    /// confignred settune the public key of the gateawy is returned.
+    pub fn onboarding_key(&self) -> PublicKey {
+        self.onboarding.as_ref().map_or_else(
+            || self.keypair.public_key().to_owned(),
+            |str| {
+                keypair::from_str(str)
+                    .map(|keypair| keypair.public_key().to_owned())
+                    .unwrap_or_else(|_| self.keypair.public_key().to_owned())
+            },
+        )
     }
 }
 


### PR DESCRIPTION
This allows for an `onboarding` setting  in default.toml to specify the onboarding key location. For most hotspots this is _not_ required since the onboarding key is the same as the public key of the hotspot. This feature is primarily for some legacy hotspots that had a different onboarding key stored in an alternate ecc slot. 