### PR TITLE
Use proper serde across more types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = ["lorawan"]
 structopt = "0"
 semver = "0"
 config = {version="0", default-features=false, features=["toml"]}
-serde = "1"
+serde = {version = "1", features = ["rc"]}
 serde_derive = "1"
 serde_json = "1"
 serde_urlencoded = "*"

--- a/src/keyed_uri.rs
+++ b/src/keyed_uri.rs
@@ -1,6 +1,6 @@
 use crate::{PublicKey, Result};
 use http::Uri;
-use serde::{de, Deserialize, Deserializer};
+use serde::Deserialize;
 use std::{fmt, str::FromStr, sync::Arc};
 
 /// A URI that has an associated public key
@@ -8,7 +8,6 @@ use std::{fmt, str::FromStr, sync::Arc};
 pub struct KeyedUri {
     #[serde(with = "http_serde::uri")]
     pub uri: Uri,
-    #[serde(deserialize_with = "deserialize_pubkey")]
     pub pubkey: Arc<PublicKey>,
 }
 
@@ -24,29 +23,6 @@ impl fmt::Debug for KeyedUri {
             .field("uri", &self.uri)
             .field("pubkey", &self.pubkey.to_string())
             .finish()
-    }
-}
-
-fn deserialize_pubkey<'de, D>(d: D) -> std::result::Result<Arc<PublicKey>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let key_string = String::deserialize(d)?;
-    match key_string.parse() {
-        Ok(key) => Ok(Arc::new(key)),
-        Err(err) => Err(de::Error::custom(format!("invalid pubkey: \"{err}\""))),
-    }
-}
-
-impl AsRef<Uri> for KeyedUri {
-    fn as_ref(&self) -> &Uri {
-        &self.uri
-    }
-}
-
-impl AsRef<PublicKey> for KeyedUri {
-    fn as_ref(&self) -> &PublicKey {
-        &self.pubkey
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn mk_logger(settings: &Settings) -> Logger {
                 .fuse();
             slog_async::Async::new(drain)
                 .build()
-                .filter_level(settings.log.level)
+                .filter_level(settings.log.level.into())
                 .fuse()
         }
         LogMethod::Stdio => {
@@ -70,7 +70,7 @@ fn mk_logger(settings: &Settings) -> Logger {
                 .fuse();
             slog_async::Async::new(drain)
                 .build()
-                .filter_level(settings.log.level)
+                .filter_level(settings.log.level.into())
                 .fuse()
         }
     };

--- a/src/region.rs
+++ b/src/region.rs
@@ -12,30 +12,49 @@ impl From<Region> for ProtoRegion {
     }
 }
 
-pub fn deserialize<'de, D>(d: D) -> std::result::Result<Region, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let region = match String::deserialize(d)?.as_str() {
-        "US915" => Region(ProtoRegion::Us915),
-        "EU868" => Region(ProtoRegion::Eu868),
-        "EU433" => Region(ProtoRegion::Eu433),
-        "CN470" => Region(ProtoRegion::Cn470),
-        "CN779" => Region(ProtoRegion::Cn779),
-        "AU915" => Region(ProtoRegion::Au915),
-        "AS923_1" => Region(ProtoRegion::As9231),
-        "AS923_2" => Region(ProtoRegion::As9232),
-        "AS923_3" => Region(ProtoRegion::As9233),
-        "AS923_4" => Region(ProtoRegion::As9234),
-        "KR920" => Region(ProtoRegion::Kr920),
-        "IN865" => Region(ProtoRegion::In865),
-        unsupported => {
-            return Err(de::Error::custom(format!(
-                "unsupported region: {unsupported}"
-            )))
+impl<'de> Deserialize<'de> for Region {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct RegionVisitor;
+
+        impl<'de> de::Visitor<'de> for RegionVisitor {
+            type Value = Region;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("region string")
+            }
+
+            fn visit_str<E>(self, value: &str) -> std::result::Result<Region, E>
+            where
+                E: de::Error,
+            {
+                let proto_region = match value {
+                    "US915" => ProtoRegion::Us915,
+                    "EU868" => ProtoRegion::Eu868,
+                    "EU433" => ProtoRegion::Eu433,
+                    "CN470" => ProtoRegion::Cn470,
+                    "CN779" => ProtoRegion::Cn779,
+                    "AU915" => ProtoRegion::Au915,
+                    "AS923_1" => ProtoRegion::As9231,
+                    "AS923_2" => ProtoRegion::As9232,
+                    "AS923_3" => ProtoRegion::As9233,
+                    "AS923_4" => ProtoRegion::As9234,
+                    "KR920" => ProtoRegion::Kr920,
+                    "IN865" => ProtoRegion::In865,
+                    unsupported => {
+                        return Err(de::Error::custom(format!(
+                            "unsupported region: {unsupported}"
+                        )))
+                    }
+                };
+                Ok(Region(proto_region))
+            }
         }
-    };
-    Ok(region)
+
+        deserializer.deserialize_str(RegionVisitor)
+    }
 }
 
 impl fmt::Display for Region {

--- a/src/service/gateway.rs
+++ b/src/service/gateway.rs
@@ -1,5 +1,7 @@
-use crate::{service::CONNECT_TIMEOUT, Error, KeyedUri, MsgSign, MsgVerify, Region, Result};
-use helium_crypto::{Keypair, PublicKey};
+use crate::{
+    service::CONNECT_TIMEOUT, Error, KeyedUri, Keypair, MsgSign, MsgVerify, PublicKey, Region,
+    Result,
+};
 use helium_proto::{
     gateway_resp_v1,
     services::{self, Channel, Endpoint},

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,6 +1,5 @@
 use crate::{
-    api::GatewayStakingMode, keypair, region, releases, Error, KeyedUri, Keypair, PublicKey,
-    Region, Result,
+    api::GatewayStakingMode, releases, Error, KeyedUri, Keypair, PublicKey, Region, Result,
 };
 use config::{Config, Environment, File};
 use http::uri::Uri;
@@ -25,7 +24,6 @@ pub struct Settings {
     pub api: u16,
     /// The location of the keypair binary file for the gateway. If the keyfile
     /// is not found there a new one is generated and saved in that location.
-    #[serde(deserialize_with = "keypair::deserialize")]
     pub keypair: Arc<Keypair>,
     /// The location of the onboarding keypair binary file for the gateway. If
     /// the keyfile is not found there a new one is generated and saved in that
@@ -33,7 +31,6 @@ pub struct Settings {
     pub onboarding: Option<String>,
     /// The lorawan region to use. This value should line up with the configured
     /// region of the semtech packet forwarder. Defaults to "US915"
-    #[serde(deserialize_with = "region::deserialize")]
     pub region: Region,
     /// Log settings
     pub log: LogSettings,
@@ -53,7 +50,6 @@ pub struct Settings {
 #[derive(Debug, Deserialize)]
 pub struct LogSettings {
     /// Log level to show (default info)
-    #[serde(deserialize_with = "log_level::deserialize")]
     pub level: log_level::Level,
 
     ///  Which log method to use (stdio or syslog, default stdio)
@@ -72,7 +68,6 @@ pub struct UpdateSettings {
     pub interval: u32,
     /// Which udpate channel to use (alpha, beta, release, semver).
     /// Defaults to semver which is the channel specified in the running app.
-    #[serde(deserialize_with = "releases::deserialize_channel")]
     pub channel: releases::Channel,
     /// The platform identifier to use for released packages (default: klkgw)
     pub platform: String,
@@ -128,7 +123,7 @@ impl Settings {
         self.onboarding.as_ref().map_or_else(
             || self.keypair.public_key().to_owned(),
             |str| {
-                keypair::from_str(str)
+                Keypair::from_str(str)
                     .map(|keypair| keypair.public_key().to_owned())
                     .unwrap_or_else(|_| self.keypair.public_key().to_owned())
             },
@@ -195,18 +190,59 @@ impl FromStr for StakingMode {
 }
 
 pub mod log_level {
-    use serde::{de, Deserialize, Deserializer};
+    use serde::de::{self, Deserialize, Deserializer, Visitor};
+    use std::fmt;
 
-    pub type Level = slog::Level;
+    #[derive(Debug, Clone, Copy)]
+    pub struct Level(slog::Level);
 
-    pub fn deserialize<'de, D>(d: D) -> std::result::Result<slog::Level, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(d)?;
-        s.parse()
-            .map_err(|_| de::Error::custom(format!("invalid log level \"{s}\"")))
+    impl AsRef<slog::Level> for Level {
+        fn as_ref(&self) -> &slog::Level {
+            &self.0
+        }
     }
+
+    impl From<Level> for slog::Level {
+        fn from(v: Level) -> Self {
+            v.0
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Level {
+        fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct LevelVisitor;
+
+            impl<'de> Visitor<'de> for LevelVisitor {
+                type Value = Level;
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("log level")
+                }
+                fn visit_str<E>(self, value: &str) -> std::result::Result<Level, E>
+                where
+                    E: de::Error,
+                {
+                    value
+                        .parse()
+                        .map(Level)
+                        .map_err(|_| de::Error::custom(format!("invalid log level \"{value}\"")))
+                }
+            }
+
+            deserializer.deserialize_str(LevelVisitor)
+        }
+    }
+
+    // pub fn deserialize<'de, D>(d: D) -> std::result::Result<slog::Level, D::Error>
+    // where
+    //     D: Deserializer<'de>,
+    // {
+    //     let s = String::deserialize(d)?;
+    //     s.parse()
+    //         .map_err(|_| de::Error::custom(format!("invalid log level \"{s}\"")))
+    // }
 }
 
 pub mod log_method {

--- a/src/traits/msg_sign.rs
+++ b/src/traits/msg_sign.rs
@@ -1,29 +1,30 @@
-use crate::{Error, Result};
+use crate::{Error, Keypair, Result};
 use futures::TryFutureExt;
-use helium_crypto::{Keypair, Sign};
+use helium_crypto::Sign;
 use helium_proto::{
     BlockchainStateChannelOfferV1, BlockchainStateChannelPacketV1, BlockchainTxnAddGatewayV1,
     BlockchainTxnStateChannelCloseV1, GatewayRegionParamsUpdateReqV1, Message,
 };
-use std::sync::Arc;
 
 #[async_trait::async_trait]
 pub trait MsgSign: Message + std::clone::Clone {
-    async fn sign(&self, keypair: Arc<Keypair>) -> Result<Vec<u8>>
+    async fn sign<T>(&self, keypair: T) -> Result<Vec<u8>>
     where
-        Self: std::marker::Sized;
+        Self: std::marker::Sized,
+        T: AsRef<Keypair> + std::marker::Send + 'static;
 }
 
 macro_rules! impl_msg_sign {
     ($txn_type:ty, $( $sig: ident ),+ ) => {
         #[async_trait::async_trait]
         impl MsgSign for $txn_type {
-            async fn sign(&self, keypair: Arc<Keypair>) -> Result<Vec<u8>> {
+            async fn sign<T>(&self, keypair: T) -> Result<Vec<u8>>
+            where T: AsRef<Keypair> + std::marker::Send + 'static {
                 let mut txn = self.clone();
                 $(txn.$sig = vec![];)+
                 let buf = txn.encode_to_vec();
                 let join_handle: tokio::task::JoinHandle<Result<Vec<u8>>> = tokio::task::spawn_blocking(move ||  {
-                    keypair.sign(&buf).map_err(Error::from)
+                    keypair.as_ref().sign(&buf).map_err(Error::from)
                 });
                 join_handle.map_err(|err| helium_crypto::Error::from(signature::Error::from_source(err))).await?
             }


### PR DESCRIPTION
Some internal refactoring to use proper serde across more types. This also uses the `rc` feature of serve to add Arc<T> deserializer support