### PR TITLE
adding a testnet router

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -89,3 +89,7 @@ uri = "http://52.8.80.146:8080"
 # production: oui 1
 pubkey = "112qB3YaH5bZkCnKA5uRH7tBtGNv2Y5B4smv1jsmvGUzgKT71QpE"
 uri = "http://52.8.80.146:8080"
+
+[router.testnet]
+pubkey = "1ZLxTAB8Bs7BXySp5HqHhtCos6JtzzV2mfZjofEGT1MQVTKqYQT"
+uri = "http://34.215.110.61:8080"


### PR DESCRIPTION
supply the testnet default router config as part of the default.toml file since it's mutually exclusive to other default routers based on the release channel setting of the running hotspot. without these values the gateway process will immediately crash for missing `uri` and `pubkey` fields