### PR TITLE
remove now-optional testnet router

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -89,7 +89,3 @@ uri = "http://52.8.80.146:8080"
 # production: oui 1
 pubkey = "112qB3YaH5bZkCnKA5uRH7tBtGNv2Y5B4smv1jsmvGUzgKT71QpE"
 uri = "http://52.8.80.146:8080"
-
-[router.testnet]
-pubkey = "1ZLxTAB8Bs7BXySp5HqHhtCos6JtzzV2mfZjofEGT1MQVTKqYQT"
-uri = "http://34.215.110.61:8080"


### PR DESCRIPTION
this is no longer needed, thanks to the addition of https://github.com/helium/gateway-rs/pull/240 so cleaning it up