### PR TITLE
Adjusts router client to stay alive

### DIFF
--- a/src/state_channel/channel.rs
+++ b/src/state_channel/channel.rs
@@ -14,7 +14,7 @@ use helium_proto::{
 use sha2::{Digest, Sha256};
 use std::{convert::TryFrom, mem};
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum StateChannelCausality {
     Effect,
     Cause,


### PR DESCRIPTION
This keeps router clients alive even if the service gateway changes to allow for packet routing to continue until new gateway is received or if no further progress can be made without a gateway.

Once a routing_client requires a gateway to continue all packets will error out until a gateway is associated.

Routing clients are stopped and removed when a routing update arrives that no longer has the target oui/keyey_uri as a pair in its list 