### PR TITLE
default routers to packet purchasers

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -45,24 +45,17 @@ command = "/etc/helium_gateway/install_update"
 [cache]
 max_packets = 20
 
-## Default routers for various release channels
-[router.alpha]
-# staging: oui 4
-# pubkey = "11263KvqW3GZPAvag5sQYtBJSjb25azSTSwoi5Tza9kboaLRxcsv"
-# uri = "http://54.193.165.228:8080"
-# dev: oui 2
-pubkey = "1124CJ9yJaHq4D6ugyPCDnSBzQik61C1BqD9VMh1vsUmjwt16HNB"
-uri = "http://54.176.88.149:8080"
+# Default target routers for data packets that are not known to helium packet
+# routers. 
+[[routers]]
+# PP-US
+pubkey = "11w77YQLhgUt8HUJrMtntGGr97RyXmot1ofs5Ct2ELTmbFoYsQa"
+uri = "http://44.238.156.97:8080"
 
-[router.beta]
-# production
-pubkey = "112qB3YaH5bZkCnKA5uRH7tBtGNv2Y5B4smv1jsmvGUzgKT71QpE"
-uri = "http://52.8.80.146:8080"
-
-[router.release]
-# production: oui 1
-pubkey = "112qB3YaH5bZkCnKA5uRH7tBtGNv2Y5B4smv1jsmvGUzgKT71QpE"
-uri = "http://52.8.80.146:8080"
+[[routers]]
+# PP-EU
+pubkey = "11afuQSrmk52mgxLu91AdtDXbJ9wmqWBUxC3hvjejoXkxEZfPvY"
+uri = "http://13.37.13.24:8080"
 
 # A list of gateway service keys and urls (note https is not supported
 [[gateways]]

--- a/src/keyed_uri.rs
+++ b/src/keyed_uri.rs
@@ -1,7 +1,12 @@
 use crate::{PublicKey, Result};
 use http::Uri;
 use serde::Deserialize;
-use std::{fmt, str::FromStr, sync::Arc};
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    str::FromStr,
+    sync::Arc,
+};
 
 /// A URI that has an associated public key
 #[derive(Clone, Deserialize, Eq)]
@@ -14,6 +19,13 @@ pub struct KeyedUri {
 impl PartialEq for KeyedUri {
     fn eq(&self, other: &Self) -> bool {
         self.uri.eq(&other.uri) && self.pubkey.eq(&other.pubkey)
+    }
+}
+
+impl Hash for KeyedUri {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.uri.hash(state);
+        self.pubkey.hash(state);
     }
 }
 

--- a/src/router/routing.rs
+++ b/src/router/routing.rs
@@ -1,7 +1,6 @@
 use super::{DevAddrFilter, EuiFilter};
 use crate::{KeyedUri, PublicKey, Result};
 use helium_proto::{routing_information::Data as RoutingData, RoutingInformation};
-use http::Uri;
 use slog::{warn, Logger};
 use std::{convert::TryFrom, sync::Arc};
 
@@ -14,8 +13,8 @@ pub struct Routing {
 }
 
 impl Routing {
-    pub fn contains_uri(&self, uri: &Uri) -> bool {
-        self.uris.iter().any(|keyed_uri| &keyed_uri.uri == uri)
+    pub fn contains_uri(&self, uri: &KeyedUri) -> bool {
+        self.uris.iter().any(|keyed_uri| keyed_uri == uri)
     }
 
     pub fn matches_routing_info(&self, routing_info: &Option<RoutingInformation>) -> bool {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -5,7 +5,7 @@ use config::{Config, Environment, File};
 use http::uri::Uri;
 pub use log_method::LogMethod;
 use serde::Deserialize;
-use std::{collections::HashMap, fmt, path::Path, str::FromStr, sync::Arc};
+use std::{fmt, path::Path, str::FromStr, sync::Arc};
 
 pub fn version() -> semver::Version {
     semver::Version::parse(env!("CARGO_PKG_VERSION")).expect("unable to parse version")
@@ -36,9 +36,9 @@ pub struct Settings {
     pub log: LogSettings,
     /// Update settings
     pub update: UpdateSettings,
-    /// The router to deliver packets to when no routers are found while
+    /// The routers to deliver packets to when no routers are found while
     /// processing a packet.
-    pub router: HashMap<String, KeyedUri>,
+    pub routers: Option<Vec<KeyedUri>>,
     /// The validator(s) to query for chain related state. Defaults to a Helium
     /// validator.
     pub gateways: Vec<KeyedUri>,
@@ -109,12 +109,6 @@ impl Settings {
             .build()
             .and_then(|config| config.try_deserialize())
             .map_err(|e| e.into())
-    }
-
-    pub fn default_router(&self) -> Option<KeyedUri> {
-        self.router
-            .get(&self.update.channel.to_string())
-            .map(|keyed_uri| keyed_uri.to_owned())
     }
 
     /// Returns the onboarding key for this gateway. The onboarding key is

--- a/src/state_channel/channel.rs
+++ b/src/state_channel/channel.rs
@@ -14,7 +14,7 @@ use helium_proto::{
 use sha2::{Digest, Sha256};
 use std::{convert::TryFrom, mem};
 
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Debug, Eq)]
 pub enum StateChannelCausality {
     Effect,
     Cause,


### PR DESCRIPTION
This is a change to default.toml where we now just have one list of default routers to target when packets are not known to exisitng helium routers. 