### PR TITLE
Run update script as a fork to fix install issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fork"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b4f1a740392e495821244cc1658d86496ac6e67a47da67e243ed401b937717"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +659,7 @@ dependencies = [
  "config",
  "daemonize",
  "exponential-backoff",
+ "fork",
  "futures",
  "helium-crypto",
  "helium-proto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,12 +203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "boxfnonce"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5988cb1d626264ac94100be357308f29ff7cbdd3b36bda27f450a4ee3f713426"
-
-[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,11 +355,9 @@ dependencies = [
 
 [[package]]
 name = "daemonize"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c24513e34f53b640819f0ac9f705b673fcf4006d7aab8778bee72ebfc89815"
+version = "0.5.0"
+source = "git+https://github.com/knsd/daemonize?rev=f7be28e#f7be28efa1b4a70e43bb37b5f4ff4d664992edca"
 dependencies = [
- "boxfnonce",
  "libc",
 ]
 
@@ -541,15 +533,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "fork"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b4f1a740392e495821244cc1658d86496ac6e67a47da67e243ed401b937717"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,7 +642,6 @@ dependencies = [
  "config",
  "daemonize",
  "exponential-backoff",
- "fork",
  "futures",
  "helium-crypto",
  "helium-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ semtech-udp = { version = ">=0.9.4,<1", default-features=false, features=["serve
 helium-proto = { git = "https://github.com/helium/proto", branch="master", features=["services"]}
 helium-crypto = { git = "https://github.com/helium/helium-crypto-rs", tag = "v0.3.4", features = ["ecc608"]}
 longfi = { git = "https://github.com/helium/longfi-rs", branch = "main" }
+fork = "0.1"
 
 [profile.release]
 opt-level = "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ thiserror = "1.0"
 base64 = "0"
 rand = "0.8"
 prost = "0"
-daemonize = "0.4"
+daemonize = {git = "https://github.com/knsd/daemonize", rev = "f7be28e"}
 tonic = "0"
 http = "*"
 log = "0"
@@ -55,7 +55,6 @@ semtech-udp = { version = ">=0.9.4,<1", default-features=false, features=["serve
 helium-proto = { git = "https://github.com/helium/proto", branch="master", features=["services"]}
 helium-crypto = { git = "https://github.com/helium/helium-crypto-rs", tag = "v0.3.4", features = ["ecc608"]}
 longfi = { git = "https://github.com/helium/longfi-rs", branch = "main" }
-fork = "0.1"
 
 [profile.release]
 opt-level = "z"

--- a/package/dragino/control/prerm
+++ b/package/dragino/control/prerm
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 /etc/init.d/helium_gateway disable
-
+/etc/init.d/helium_gateway stop

--- a/package/ramips_24kec/control/prerm
+++ b/package/ramips_24kec/control/prerm
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 /etc/init.d/helium_gateway disable
-
+/etc/init.d/helium_gateway stop


### PR DESCRIPTION
### Problem Statement
When running an update, the existing service never terminates the currently running instance of helium_gateway. By leaving the service running, it causes the gateway to be inoperable when the new version is installed. Rebooting the gateway resolves this. However, even with a reboot and the gateway functioning, the opkg package manager is out of sync. `opkg list` will continue to show the old version. This appears to be related to the fact that the update install script is running as part of the existing service.

### Solution
First, as part of the `prerm` (pre-removal) script that is called as part of an update, add a call to stop the current helium_gateway service. However, because this terminates the service that is running the upgrade, this causes it's own issues. So, secondly, this update also forks the process before calling the update install script. This ensures that the install script survives after the gateway service is stopped.

### Open Issues
Currently, the logging does not work in the forked child process. I am not sure if this is because the logger is async and the process terminates before allowing the logging to complete, or if the logger is just not accessible to the fork for some reason. I could use some help/insight into that. I tested this on a Dragino and RAK WisGate by rebasing this PR on the alpha.25 tag