### PR TITLE
Initialize hold_time as early as possible

### DIFF
--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -1,4 +1,7 @@
-use crate::{router::dispatcher, Error, Packet, RegionParams, Result, Settings};
+use crate::{
+    router::{dispatcher, QuePacket},
+    Error, Packet, RegionParams, Result, Settings,
+};
 use futures::TryFutureExt;
 use semtech_udp::{
     server_runtime::{Error as SemtechError, Event, UdpRuntime},
@@ -108,7 +111,7 @@ impl Gateway {
             Event::ClientDisconnected((mac, addr)) => {
                 info!(logger, "disconnected packet forwarder: {mac}, {addr}")
             }
-            Event::PacketReceived(rxpk, _gateway_mac) => match Packet::try_from(rxpk) {
+            Event::PacketReceived(rxpk, _gateway_mac) => match QuePacket::try_from(rxpk) {
                 Ok(packet) if packet.is_longfi() => {
                     info!(logger, "ignoring longfi packet");
                 }
@@ -127,7 +130,7 @@ impl Gateway {
         Ok(())
     }
 
-    async fn handle_uplink(&mut self, logger: &Logger, packet: Packet) {
+    async fn handle_uplink(&mut self, logger: &Logger, packet: QuePacket) {
         info!(logger, "uplink {} from {}", packet, self.downlink_mac);
         match self.uplinks.uplink(packet).await {
             Ok(()) => (),

--- a/src/router/client.rs
+++ b/src/router/client.rs
@@ -19,7 +19,7 @@ pub const STATE_CHANNEL_CONNECT_INTERVAL: Duration = Duration::from_secs(60);
 
 #[derive(Debug)]
 pub enum Message {
-    Uplink(Packet),
+    Uplink(QuePacket),
     RegionChanged(Region),
     Stop,
 }
@@ -38,7 +38,7 @@ impl MessageSender {
         let _ = self.0.send(Message::RegionChanged(region)).await;
     }
 
-    pub async fn uplink(&self, packet: Packet) -> Result {
+    pub async fn uplink(&self, packet: QuePacket) -> Result {
         self.0
             .send(Message::Uplink(packet))
             .map_err(|_| Error::channel())
@@ -130,7 +130,7 @@ impl RouterClient {
         }
     }
 
-    async fn handle_uplink(&mut self, logger: &Logger, uplink: Packet) -> Result {
+    async fn handle_uplink(&mut self, logger: &Logger, uplink: QuePacket) -> Result {
         self.store.store_waiting_packet(uplink)?;
         self.send_waiting_packets(logger).await
     }

--- a/src/router/dispatcher.rs
+++ b/src/router/dispatcher.rs
@@ -1,8 +1,8 @@
 use crate::{
     gateway,
-    router::{self, RouterClient, Routing},
+    router::{self, QuePacket, RouterClient, Routing},
     service::{self, gateway::GatewayService},
-    sync, CacheSettings, Error, KeyedUri, Keypair, Packet, Region, Result, Settings,
+    sync, CacheSettings, Error, KeyedUri, Keypair, Region, Result, Settings,
 };
 use exponential_backoff::Backoff;
 use futures::{
@@ -18,7 +18,7 @@ use tokio_stream::{self, StreamExt, StreamMap};
 
 #[derive(Debug)]
 pub enum Message {
-    Uplink(Packet),
+    Uplink(QuePacket),
     Config {
         keys: Vec<String>,
         response: sync::ResponseSender<Result<Vec<BlockchainVarV1>>>,
@@ -59,7 +59,7 @@ impl MessageSender {
         rx.recv().await?
     }
 
-    pub async fn uplink(&self, packet: Packet) -> Result {
+    pub async fn uplink(&self, packet: QuePacket) -> Result {
         self.0
             .send(Message::Uplink(packet))
             .map_err(|_| Error::channel())
@@ -386,7 +386,7 @@ impl Dispatcher {
         }
     }
 
-    async fn handle_uplink(&self, packet: &Packet, logger: &Logger) {
+    async fn handle_uplink(&self, packet: &QuePacket, logger: &Logger) {
         let mut handled = false;
         for router_entry in self.routers.values() {
             if router_entry.routing.matches_routing_info(packet.routing()) {

--- a/src/router/store.rs
+++ b/src/router/store.rs
@@ -1,6 +1,9 @@
-use crate::{CacheSettings, Packet, Result};
+use semtech_udp::push_data;
+
+use crate::{CacheSettings, Error, Packet, Result};
 use std::{
     collections::VecDeque,
+    fmt,
     ops::Deref,
     time::{Duration, Instant},
 };
@@ -10,7 +13,7 @@ pub struct RouterStore {
     max_packets: u16,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct QuePacket {
     received: Instant,
     packet: Packet,
@@ -41,6 +44,21 @@ impl From<Packet> for QuePacket {
     }
 }
 
+impl fmt::Display for QuePacket {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_fmt(format_args!("since: {:?}, {}", self.received, self.packet))
+    }
+}
+
+impl TryFrom<push_data::RxPk> for QuePacket {
+    type Error = Error;
+
+    fn try_from(rxpk: push_data::RxPk) -> Result<Self> {
+        let packet = Packet::try_from(rxpk)?;
+        Ok(Self::from(packet))
+    }
+}
+
 impl RouterStore {
     pub fn new(settings: &CacheSettings) -> Self {
         let max_packets = settings.max_packets;
@@ -51,8 +69,8 @@ impl RouterStore {
         }
     }
 
-    pub fn store_waiting_packet(&mut self, packet: Packet) -> Result {
-        self.waiting_packets.push_back(QuePacket::from(packet));
+    pub fn store_waiting_packet(&mut self, packet: QuePacket) -> Result {
+        self.waiting_packets.push_back(packet);
         if self.waiting_packets_len() > self.max_packets as usize {
             self.waiting_packets.pop_front();
         }


### PR DESCRIPTION
Without shoving it into the radio layer, we want to know how long the packet is sitting in the system.
When a gateway is already connected, the hold_time is `0` and that doesn't really tell us anything.