### PR TITLE
configure default mainnet poc ingest uri

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -47,7 +47,7 @@ max_packets = 20
 
 [poc]
 entropy_uri = "https://entropy.helium.io:8080"
-ingest_uri = "http://todo:1234"
+ingest_uri = "http://mainnet-pociot.helium.io:9980"
 
 # Default target routers for data packets that are not known to helium packet
 # routers. 


### PR DESCRIPTION
Note that the ingest_uri is not `https` because of lack of consistent/recent ssl certs and implementations on a number of embedded platforms. 

cc @jadeallenx 