### PR TITLE
Fix spelling

### DIFF
--- a/src/beaconer.rs
+++ b/src/beaconer.rs
@@ -199,7 +199,7 @@ impl Beaconer {
 fn test_beacon_roundtrip() {
     use lorawan::PHYPayload;
 
-    let phy_payload_a = PHYPayload::propietary(b"poc_beacon_data");
+    let phy_payload_a = PHYPayload::proprietary(b"poc_beacon_data");
     let payload: Vec<u8> = phy_payload_a.clone().try_into().expect("beacon packet");
     let phy_payload_b = PHYPayload::read(lorawan::Direction::Uplink, &mut &payload[..]).unwrap();
     assert_eq!(phy_payload_a, phy_payload_b);


### PR DESCRIPTION
Fixes the following failure to run the tests:

```
$ cargo test
   Compiling gateway-rs v1.0.0-alpha.31 (gateway-rs.main)
error[E0599]: no function or associated item named `propietary` found for struct `PHYPayload` in the current scope
   --> src/beaconer.rs:202:37
    |
202 |     let phy_payload_a = PHYPayload::propietary(b"poc_beacon_data");
    |                                     ^^^^^^^^^^
    |                                     |
    |                                     function or associated item not found in `PHYPayload`
    |                                     help: there is an associated function with a similar name: `proprietary`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `gateway-rs` due to previous error
```