### PR TITLE
fixing workspace dependencies; config values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ log = "0"
 bytes = "*"
 xxhash-rust = { version = "0.8", features = ["xxh64"]}
 xorf = "0.7"
-sha2 = {workspace = true }
+sha2 = {workspace = true}
 base64 = {workspace = true}
 signature = "*"
 async-trait = "0"

--- a/config/default.toml
+++ b/config/default.toml
@@ -46,8 +46,8 @@ command = "/etc/helium_gateway/install_update"
 max_packets = 20
 
 [poc]
-entropy_uri = "https://entropy.helium.io:8080"
-ingest_uri = "http://mainnet-pociot.helium.io:9980"
+entropy_uri = "https://entropy.helium.io/entropy"
+ingest_uri = "http://mainnet-pociot.helium.io:9080"
 
 # Default target routers for data packets that are not known to helium packet
 # routers. 

--- a/src/beaconer.rs
+++ b/src/beaconer.rs
@@ -115,7 +115,7 @@ impl Beaconer {
         let report = match poc_lora::LoraBeaconReportReqV1::try_from(beacon.clone()) {
             Ok(report) => report,
             Err(err) => {
-                warn!(logger, "failed to construct beack report {err:?}");
+                warn!(logger, "failed to construct beacon report {err:?}");
                 return;
             }
         };
@@ -199,7 +199,7 @@ impl Beaconer {
 fn test_beacon_roundtrip() {
     use lorawan::PHYPayload;
 
-    let phy_payload_a = PHYPayload::propietary(b"poc_beacon_data");
+    let phy_payload_a = PHYPayload::proprietary(b"poc_beacon_data");
     let payload: Vec<u8> = phy_payload_a.clone().try_into().expect("beacon packet");
     let phy_payload_b = PHYPayload::read(lorawan::Direction::Uplink, &mut &payload[..]).unwrap();
     assert_eq!(phy_payload_a, phy_payload_b);


### PR DESCRIPTION
Fixes some configuration values for the default endpoints the helium_gateway should call to in order to receive the remote entropy data as well as the default (mainnet) endpoint for submitting beacon reports to.

re-introduces the tonic client request interceptor from early testing to allow injecting an "auth" token into the post requests to the grpc beacon ingestor service.

since these requests will be over plaintext http2 and not https2 this token is intended more as a "fail fast if the beacon is not intended for the network in question and as a result is named "ingest token" instead of "auth token" (or similar) in the public-facing configuration and defaults to `mainnet`