### PR TITLE
add missing 125 proto datarate

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -187,6 +187,7 @@ impl Packet {
                     ProtoDataRate::Sf8bw125,
                     ProtoDataRate::Sf9bw125,
                     ProtoDataRate::Sf10bw125,
+                    ProtoDataRate::Sf11bw125,
                     ProtoDataRate::Sf12bw125,
                 ]
                 .contains(&value) =>


### PR DESCRIPTION
@mikev noticed this SF11 datarate option from the proto repo was missing from this slice of available data rates that could cause problems in the future if we ever randomly selected from the available options.