### PR TITLE
Derive Max Transmit Power from Tx Error

### DIFF
--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -73,7 +73,7 @@ pub struct Gateway {
     listen_address: String,
     region_params: Option<RegionParams>,
     /// If packet forwarder returns InvalidTxPower, it provides the max allowable tx value
-    /// which we can save and apply it as a maximum to outgoing packets
+    /// which we can save and apply as a maximum to future outgoing packets
     max_power: Option<u32>,
 }
 

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -186,7 +186,7 @@ impl Gateway {
         let region_params = if let Some(region_params) = &self.region_params {
             region_params
         } else {
-            warn!(logger, "ignoring transmit request, no region params");
+            warn!(logger, "ignoring transmit: no region params");
             return None;
         };
 
@@ -197,7 +197,7 @@ impl Gateway {
                 tx_power
             })
         } else {
-            warn!(logger, "ignoring beacon transmit, no tx power");
+            warn!(logger, "ignoring transmit: region params has no tx power");
             None
         }
     }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -190,12 +190,10 @@ impl Gateway {
             return None;
         };
 
-        if let Some(tx_power) = region_params.tx_power() {
-            Some(if let Some(max_power) = self.max_power {
-                std::cmp::min(max_power, tx_power)
-            } else {
-                tx_power
-            })
+        if let (Some(tx_power), Some(max_power)) = (region_params.tx_power(), self.max_power) {
+            Some(std::cmp::min(max_power, tx_power))
+        } else if let Some(tx_power) = region_params.tx_power() {
+            Some(tx_power)
         } else {
             warn!(logger, "ignoring transmit: region params has no tx power");
             None

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,9 +13,15 @@ pub async fn run(shutdown: &triggered::Listener, settings: &Settings, logger: &L
     let (dispatcher_tx, dispatcher_rx) = dispatcher::message_channel(20);
     let (beaconing_tx, beaconing_rx) = beaconer::message_channel(10);
     let mut beaconer = beaconer::Beaconer::new(settings, gateway_tx.clone(), beaconing_rx);
-    let mut dispatcher = Dispatcher::new(dispatcher_rx, gateway_tx, settings)?;
-    let mut gateway =
-        gateway::Gateway::new(dispatcher_tx.clone(), gateway_rx, beaconing_tx, settings).await?;
+    let mut dispatcher = Dispatcher::new(dispatcher_rx, gateway_tx.clone(), settings)?;
+    let mut gateway = gateway::Gateway::new(
+        dispatcher_tx.clone(),
+        gateway_tx,
+        gateway_rx,
+        beaconing_tx,
+        settings,
+    )
+    .await?;
     let updater = Updater::new(settings)?;
     let api = LocalServer::new(dispatcher_tx, settings)?;
     info!(logger,


### PR DESCRIPTION
Whenever we transmit, we spawn a thread and await the ack which may contain a tx power error. I extended the existing channel for clients in the gateway module so that I could send the maximum tx power from a spawned thread.