### PR TITLE
return tx power and tmst to poc reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#3c06cc7729a0b9db5d3a63e057ec3b5da9f0bf19"
+source = "git+https://github.com/helium/proto?branch=master#eb8d4c7805b57e59d1dfb019e582fb1234765f1c"
 dependencies = [
  "bytes",
  "prost",

--- a/beacon/src/beacon.rs
+++ b/beacon/src/beacon.rs
@@ -92,6 +92,7 @@ impl TryFrom<Beacon> for poc_lora::LoraBeaconReportReqV1 {
             frequency: v.frequency,
             channel: 0,
             datarate: v.datarate as i32,
+            tmst: 0,
             tx_power: 27,
             // The timestamp of the beacon is the timestamp of creation of the
             // report (in nanos)

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,8 @@ pub enum Error {
     Semtech(#[from] semtech_udp::server_runtime::Error),
     #[error("beacon error")]
     Beacon(#[from] beacon::Error),
+    #[error("gateway error: {0}")]
+    Gateway(#[from] crate::gateway::GatewayError),
     #[error("region error")]
     Region(#[from] RegionError),
     #[error("curl error")]
@@ -83,6 +85,8 @@ pub enum ServiceError {
 pub enum RegionError {
     #[error("no region params found or active")]
     NoRegionParams,
+    #[error("no region tx power defined in region params")]
+    NoRegionTxPower,
 }
 
 macro_rules! from_err {
@@ -139,6 +143,10 @@ impl DecodeError {
 impl RegionError {
     pub fn no_region_params() -> Error {
         Error::Region(RegionError::NoRegionParams)
+    }
+
+    pub fn no_region_tx_power() -> Error {
+        Error::Region(RegionError::NoRegionTxPower)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,8 @@ pub enum Error {
     Region(#[from] RegionError),
     #[error("curl error")]
     Curl(#[from] crate::curl::Error),
+    #[error("system time")]
+    SystemTime(#[from] std::time::SystemTimeError),
 }
 
 #[derive(Error, Debug)]

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -202,8 +202,8 @@ impl Packet {
         let report = poc_lora::LoraWitnessReportReqV1 {
             pub_key: vec![],
             data: payload,
+            tmst: self.timestamp as u32,
             timestamp: self.timestamp,
-            ts_res: 0,
             signal: (self.signal_strength * 10.0) as i32,
             snr: (self.snr * 10.0) as i32,
             frequency: to_hz(self.frequency),


### PR DESCRIPTION
Returns tmst and tx_power/powe fields from transmitted beacons to the beaconer caller to update poc beacon reports with the actual values used in the transmission, as well as pulling the tmst value from poc witness packets into the associated witness reports. This should enable creation of second-order beacons