### PR TITLE
Add some jitter to beacon intervals

### DIFF
--- a/lorawan/src/error.rs
+++ b/lorawan/src/error.rs
@@ -11,10 +11,10 @@ pub enum LoraWanError {
 impl fmt::Display for LoraWanError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            LoraWanError::InvalidPacketType(v) => write!(f, "Invalid packet type: {:#02x}", v),
+            LoraWanError::InvalidPacketType(v) => write!(f, "Invalid packet type: {v:#02x}"),
             LoraWanError::InvalidFPortForFopts => write!(f, "Invalid: fport 0 with fopts"),
             LoraWanError::InvalidPacketSize(mtype, s) => {
-                write!(f, "Invalid packet size {} for type {:?}", s, mtype)
+                write!(f, "Invalid packet size {s} for type {mtype:?}")
             }
             LoraWanError::Io(err) => err.fmt(f),
         }

--- a/src/cmd/update.rs
+++ b/src/cmd/update.rs
@@ -88,11 +88,11 @@ impl Download {
                     .join(&asset.name);
                 match asset.download(&download_path).await {
                     Ok(()) => println!("Downloaded to: {}", download_path.to_string_lossy()),
-                    Err(err) => eprintln!("Failed to download update: {:?}", err),
+                    Err(err) => eprintln!("Failed to download update: {err:?}"),
                 }
             }
             Ok(None) => eprintln!("No release found"),
-            Err(err) => eprintln!("Error finding release: {:?}", err),
+            Err(err) => eprintln!("Error finding release: {err:?}"),
         }
         Ok(())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,7 @@ pub enum Error {
     #[error("service error: {0}")]
     Service(#[from] ServiceError),
     #[error("semtech udp error")]
-    Semtech(#[from] semtech_udp::server_runtime::Error),
+    Semtech(#[from] Box<semtech_udp::server_runtime::Error>),
     #[error("beacon error")]
     Beacon(#[from] beacon::Error),
     #[error("gateway error: {0}")]

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -106,7 +106,7 @@ impl Gateway {
             messages,
             beacon_handler,
             listen_address: settings.listen.clone(),
-            udp_runtime: UdpRuntime::new(&settings.listen).await?,
+            udp_runtime: UdpRuntime::new(&settings.listen).await.map_err(Box::new)?,
             region_params: None,
         };
         Ok(gateway)

--- a/src/keypair.rs
+++ b/src/keypair.rs
@@ -185,7 +185,7 @@ mod tests {
     #[test]
     fn keypair_args() {
         let uri = &Uri::from_static("ecc://i2c-1:196?slot=22&network=testnet");
-        let args = KeypairArgs::from_uri(&uri).expect("keypair args");
+        let args = KeypairArgs::from_uri(uri).expect("keypair args");
         assert_eq!(22, args.get::<u8>("slot", 22).expect("slot"));
         assert_eq!(196, uri.port_u16().expect("uri port"));
         assert_eq!(

--- a/src/router/filter.rs
+++ b/src/router/filter.rs
@@ -80,7 +80,7 @@ mod tests {
         #[test]
         fn from_bin_1() {
             static MASK: [u8; 6] = [0, 2, 0, 127, 255, 0];
-            let filter = DevAddrFilter::from_bin(&MASK);
+            let filter = DevAddrFilter::from_bin(MASK);
             assert_eq!(1024, filter.base);
             assert_eq!(1024, filter.size);
             assert!(filter.contains(&1024));
@@ -89,7 +89,7 @@ mod tests {
         #[test]
         fn from_bin_2() {
             static MASK: [u8; 6] = [0, 4, 4, 127, 255, 254];
-            let filter = DevAddrFilter::from_bin(&MASK);
+            let filter = DevAddrFilter::from_bin(MASK);
             assert_eq!(2056, filter.base);
             assert_eq!(8, filter.size);
             assert!(filter.contains(&2063));
@@ -107,7 +107,7 @@ mod tests {
                 0, 1, 0, 0, 0, 168, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 236, 22, 0, 0, 0, 0, 1,
                 104, 2, 0,
             ];
-            let filter = EuiFilter::from_bin(&EMPTY_BIN);
+            let filter = EuiFilter::from_bin(EMPTY_BIN);
             assert!(!filter.contains(&Eui {
                 deveui: 0,
                 appeui: 0,
@@ -136,7 +136,7 @@ mod tests {
                 0, 0, 0, 223, 21, 0, 0, 198, 225, 145, 206, 0, 0, 99, 63, 0, 0, 217, 218, 224, 20,
                 0, 0, 0, 0, 0, 0, 0, 0,
             ];
-            let filter = EuiFilter::from_bin(&SOME_FILTER_BIN);
+            let filter = EuiFilter::from_bin(SOME_FILTER_BIN);
             assert!(!filter.contains(&Eui {
                 appeui: 0,
                 deveui: 0,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -203,7 +203,7 @@ impl FromStr for StakingMode {
             "light" => Ok(Self::Light),
             "full" => Ok(Self::Full),
             "dataonly" => Ok(Self::DataOnly),
-            _ => Err(Error::custom(format!("invalid staking mode {}", v))),
+            _ => Err(Error::custom(format!("invalid staking mode {v}"))),
         }
     }
 }
@@ -246,7 +246,7 @@ pub mod log_level {
                     value
                         .parse()
                         .map(Level)
-                        .map_err(|_| de::Error::custom(format!("invalid log level \"{}\"", value)))
+                        .map_err(|_| de::Error::custom(format!("invalid log level \"{value}\"")))
                 }
             }
 
@@ -298,8 +298,7 @@ pub mod log_method {
                         "syslog" => LogMethod::Syslog,
                         unsupported => {
                             return Err(de::Error::custom(format!(
-                                "unsupported log method: \"{}\"",
-                                unsupported
+                                "unsupported log method: \"{unsupported}\""
                             )))
                         }
                     };


### PR DESCRIPTION
This PR closes off a long-standing TODO in the beacon module. The motivation is to reduce the possibility of a thundering herd situation where gateways all beacon at the same time. It shouldn't be possible generally, because the previous beacon timer was relative to start-up time, but this additional jitter reduces the risk.

Requested by @Vagabond 