### PR TITLE
Change default beacon interval to 6 hours

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -98,9 +98,9 @@ pub struct PocSettings {
     /// Remote ingestor URL.
     #[serde(with = "http_serde::uri")]
     pub ingest_uri: Uri,
-    /// Beacon interval in seconds. Defaults to 3 times in 24 hours. Note that
-    /// the rate of beacons is verified by the oracle so increasing this number
-    /// will not increase rewards
+    /// Beacon interval in seconds. Defaults to 6 hours. Note that the rate of
+    /// beacons is verified by the oracle so increasing this number will not
+    /// increase rewards
     #[serde(default = "default_poc_interval")]
     pub interval: u64,
 }
@@ -154,8 +154,8 @@ fn default_api() -> u16 {
 }
 
 fn default_poc_interval() -> u64 {
-    // 3x daily with a few seconds to spare.
-    8 * (3600 - 1)
+    // every 6 hours
+    6 * 3600
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This changes the default beacon interval to every 6 hours (instead of every 8) for initial fleet wide hotspot based beaconing. 