### PR TITLE
Pin b64 to v0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = ["lorawan", "beacon"]
 serde = {version = "1", features = ["rc", "derive"]}
 helium-proto = { git = "https://github.com/helium/proto", branch="master", features=["services"]}
 rand = "0.8"
-base64 = "0"
+base64 = "0.13"
 sha2 = "0"
 thiserror = "1.0"
 


### PR DESCRIPTION
base64 crate has been updated to [v0.20](https://github.com/marshallpierce/rust-base64/releases/tag/v0.20.0) last week, breaking the API compatibility. As this new API is [still questioned](https://github.com/marshallpierce/rust-base64/issues/205), and migration [not yet documented](https://github.com/marshallpierce/rust-base64/issues/206#issuecomment-1354047328) I figure that it is safer to pin the version to `0.13` instead of `0`