### PR TITLE
smartharvest target: updating order in start sequence

### DIFF
--- a/package/smartharvest/data/etc/init.d/helium_gateway
+++ b/package/smartharvest/data/etc/init.d/helium_gateway
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 
-START=99
-STOP=99
+START=90
+STOP=90
 USE_PROCD=1
 
 PROG="/usr/bin/helium_gateway"


### PR DESCRIPTION
Our LoRa Packet Forwarder program now relies on gateway-rs to provide the regulatory region for the radio. This change makes gateway-rs start before the lora pkt fwd program.