### PR TITLE
Use a reconnect backoff to back of on errors

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -29,7 +29,7 @@ method = "stdio"
 # The logging level to assume on startup
 level = "info"
 # Whether the logged output should include timestamps
-timestamp = false
+timestamp = true
 
 [poc]
 # The uri to fetch entropy for poc beacons


### PR DESCRIPTION
Instead of waitint 30 minutes on a failure to (re)connect to the packet router, use an exponential backoff on errors.