### PR TITLE
Temporarily disable config response signature check

### DIFF
--- a/src/service/config.rs
+++ b/src/service/config.rs
@@ -1,6 +1,6 @@
 use crate::{
     service::{CONNECT_TIMEOUT, RPC_TIMEOUT},
-    KeyedUri, Keypair, MsgSign, MsgVerify, Region, RegionParams, Result,
+    KeyedUri, Keypair, MsgSign, Region, RegionParams, Result,
 };
 use helium_proto::services::{self, iot_config::GatewayRegionParamsReqV1, Channel, Endpoint};
 use std::sync::Arc;
@@ -38,7 +38,8 @@ impl ConfigService {
         req.signature = req.sign(keypair).await?;
 
         let resp = self.client.region_params(req).await?.into_inner();
-        resp.verify(&self.uri.pubkey)?;
+        // TODO: re-enable when config service public prod key is established
+        // resp.verify(&self.uri.pubkey)?;
         Ok(RegionParams::try_from(resp)?)
     }
 }


### PR DESCRIPTION
This will be corrected as part of config oracle production launch