### PR TITLE
Add cargo make back

### DIFF
--- a/.github/cross-docker/Dockerfile-cross-debian-11
+++ b/.github/cross-docker/Dockerfile-cross-debian-11
@@ -1,0 +1,23 @@
+FROM debian:11-slim
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
+    g++-x86-64-linux-gnu \
+    libc6-dev-amd64-cross \
+    libtss2-dev \
+    llvm-dev \
+    libclang-dev \
+    clang    
+
+ENV CROSS_TOOLCHAIN_PREFIX=x86_64-linux-gnu-
+ENV CROSS_SYSROOT=/usr/x86_64-linux-gnu
+ENV CROSS_TARGET_RUNNER="/linux-runner x86_64"
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="$CROSS_TOOLCHAIN_PREFIX"gcc \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="$CROSS_TARGET_RUNNER" \
+    AR_x86_64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"ar \
+    CC_x86_64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"gcc \
+    CXX_x86_64_unknown_linux_gnu="$CROSS_TOOLCHAIN_PREFIX"g++ \
+    BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_gnu="--sysroot=$CROSS_SYSROOT" \
+    RUST_TEST_THREADS=1 \
+    PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig/:${PKG_CONFIG_PATH}"
+ENV CPATH="/usr/include/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ on:
 
 name: ci
 
-env:
-  BUILD_CMD: cross
-
 jobs:
   hygiene:
     runs-on: ubuntu-22.04
@@ -51,23 +48,14 @@ jobs:
           - aarch64-unknown-linux-gnu
           - mips-unknown-linux-musl
           - mipsel-unknown-linux-musl
-          - x86_64-unknown-linux-gnu
-        feature:
-          - ecc608
-        include:
-          - target: x86_64-unknown-linux-gnu
-            feature: tpm
+          - x86_64-tpm-debian-gnu
+
     steps:
       - uses: dtolnay/rust-toolchain@stable
+      - uses: davidB/rust-cargo-make@v1
       - uses: actions/checkout@v3
 
-      - name: install dependencies
-        if: ${{ matrix.feature == 'tpm' }}
-        run: |
-          sudo apt-get install -y libtss2-dev llvm-dev libclang-dev clang
-
       - name: install cross
-        if: ${{ ! startsWith(matrix.target, 'x86_64') }}
         uses: jaxxstorm/action-install-gh-release@v1.9.0
         env:
           ## Allow cross install into PATH
@@ -76,35 +64,18 @@ jobs:
         with:
           repo: rust-embedded/cross
 
-      - name: confirm build command
-        if: ${{ startsWith(matrix.target, 'x86_64') }}
-        run: |
-          echo "BUILD_CMD=cargo" >> $GITHUB_ENV
+      - name: build target
+        run: cargo make --profile ${{ matrix.target }} build
 
-      - name: build binary
-        run: |
-          ${{ env.BUILD_CMD }} \
-            build \
-            --target ${{ matrix.target }} \
-            --no-default-features \
-            --features ${{ matrix.feature }} \
-            --release
-          cp config/settings.toml target/${{ matrix.target }}/release
-          tar -zcvf helium-gateway-${{ matrix.feature }}-${{ matrix.target }}.tar.gz \
-            -C target/${{ matrix.target }}/release \
-              helium_gateway \
-              settings.toml
-        env:
-          RUST_BACKTRACE: 1
-          LIBCLANG_PATH: "/usr/lib/llvm-14/lib/"
+      - name: package target
+        run: cargo make --profile ${{ matrix.target }} pkg
 
-      - name: cache binary
+      - name: cache artifact
         uses: actions/upload-artifact@v3
         with:
-          name: helium-gateway-${{ matrix.feature }}-${{ matrix.target }}
+          name: helium-gateway-${{ matrix.target }}
           if-no-files-found: error
-          path: |
-            helium-gateway-${{ matrix.feature }}-${{ matrix.target }}.tar.gz
+          path: helium-gateway-*.tar.gz
 
   release:
     if: startsWith(github.ref, 'refs/tags')
@@ -122,6 +93,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ steps.vars.outputs.tag }}
-          name: Release ${{ steps.vars.outputs.tag }}
+          fail_on_unmatched_files: true
           files: helium-gateway-*.tar.gz

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,36 @@
+[env]
+CROSS_TARGET = "${CARGO_MAKE_PROFILE}"
+FEATURES = "ecc608"
+BUILD_COMMAND = "cross"
+TAR = { source = "${CARGO_MAKE_RUST_TARGET_OS}", default_value = "linux", mapping = {"macos" = "gtar", "linux" = "tar" } }
+
+[env.x86_64-tpm-debian-gnu]
+CROSS_TARGET = "x86_64-unknown-linux-gnu"
+CROSS_BUILD_DOCKERFILE = "./.github/cross-docker/Dockerfile-cross-debian-11"
+FEATURES = "tpm"
+
+[tasks.build]
+description = "Runs the cross/cargo rust compiler."
+condition = { env_set = ["CROSS_TARGET", "BUILD_COMMAND", "FEATURES"] }
+workspace = false
+command = "${BUILD_COMMAND}"
+args = [
+  "build",
+  "--target",
+  "${CROSS_TARGET}",
+  "--no-default-features",
+  "--features",
+  "${FEATURES}",
+  "--release"
+]
+
+[tasks.pkg]
+description = "Package application"
+workspace = false
+condition = { env_set = ["CARGO_MAKE_PROFILE", "CROSS_TARGET"]}
+env = { PKG_NAME = "helium-gateway-${CARGO_MAKE_CRATE_VERSION}-${CARGO_MAKE_PROFILE}" }
+script = '''
+  cp config/settings.toml target/${CROSS_TARGET}/release
+  ${TAR} -zcv -C target/${CROSS_TARGET}/release -f ${PKG_NAME}.tar.gz helium_gateway settings.toml
+'''
+

--- a/README.md
+++ b/README.md
@@ -113,8 +113,12 @@ and the local packet forwarder client connecting to the gateway service.
 The following targets are being built. Adding a new target involves creating a
 pull request against this repository with the right cpu target tuple.
 
-- Review [the open issues](https://github.com/helium/gateway-rs/issues) to see if it's already in progress. If not, file an issue.
-- Join the `#gateway` channel on [Helium Discord](https://discord.gg/helium) and let us know what platform we're missing.
+- Review [the open issues](https://github.com/helium/gateway-rs/issues) to see
+  if it's already in progress. If not, file an issue. Note that new targets are
+  developed and supported by Helium makers and Community members.
+- Join the `#gateway-development` channel on [Helium
+  Discord](https://discord.gg/helium) and work the the community to add target
+  support.
 
 Note that platforms will be tested much faster if you join the development process!
 
@@ -140,10 +144,9 @@ Note that platforms will be tested much faster if you join the development proce
 |                                | :white_check_mark: [Kona Micro] IoT Gateway                                                                                 |
 |                                | :white_check_mark: [Kona Enterprise] IoT Gateway                                                                            |
 |                                | :white_check_mark: [RisingHF RHF2S027] Light Hotspot                                                                        |
-| x86_64-unknown-linux-gnu       | :white_check_mark: Debian x86_64                                                                                            |
+| x86_64-tpm-debian-gnu          | :white_check_mark: Debian x86_64 (tpm)                                                                                      |
 |                                | :white_check_mark: FreedomfFi gateway                                                                                       |
 
-[ramips_24kec]: https://downloads.rakwireless.com/WIFI/RAK634/Hardware%20Specification/RAK634_Module_Specification_V1.0.pdf
 [rak833]: https://github.com/RAKWireless/RAK2247-RAK833-LoRaGateway-OpenWRT-MT7628
 [rak7258]: https://store.rakwireless.com/products/rak7258-micro-gateway
 [rak7249]: https://store.rakwireless.com/products/rak7249-diy-outdoor-gateway
@@ -178,12 +181,12 @@ target as part of the supported matrix of gateway platforms!
    ```shell
    cargo install cross
    ```
-3. Build the application binary using the target triplet from the supported
-   targets. Note the use of the `--release` flag to optimize the target
-   binary for size. Debug builds may be to large to run on some targets.
+3. Build the application binary using the target triplet/profile from the
+   supported targets. Note that debug builds may be to large to run on some
+   targets.
 
    ```shell
-   cross build --target <target> --release
+   cargo build --profile <target> --release build
    ```
 
    The resulting application binary is located in
@@ -191,6 +194,9 @@ target as part of the supported matrix of gateway platforms!
    ```
    target/<target>/release/helium_gateway
    ```
+
+   **NOTE** The target triplet and profile may not be the same. For example the
+   `x86_64-tpm-debian-gnu` profile uses the `x86_64-unknown-linux-gnu` target
 
 ## Additional usage info
 


### PR DESCRIPTION
The need to have alternate configuration setups made a simple `cross` build setup non trivial. This PR adds `cargo-make` to allow profiles that are not a simple target triplet (like the debian tpm setup)