### PR TITLE
Add multi-arch docker image compatibility.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,3 +95,16 @@ jobs:
         with:
           fail_on_unmatched_files: true
           files: helium-gateway-*.tar.gz
+
+  buildx:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Build multi-architecture Docker image
+        run: docker buildx build --platform linux/arm64,linux/amd64 .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,5 +106,21 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
 
-      - name: Build multi-architecture Docker image
-        run: docker buildx build --platform linux/arm64,linux/amd64 .
+      - name: Login to Quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_TEST_USER }}
+          password: ${{ secrets.QUAY_TEST_UPLOAD_TOKEN }}
+
+      # The following is for testing this PR only. This will be
+      # replaced with tag-gated publishing to
+      # quay.io/team-helium/test-images, along with proper
+      # git-tag-based image-tags
+      - name: Publish Docker image
+        run: |
+          docker buildx build \
+          --platform linux/arm64,linux/amd64 \
+          --tag quay.io/team-helium/test-images:gwrs-pr-353 \
+          --push \
+          .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,12 +96,13 @@ jobs:
           fail_on_unmatched_files: true
           files: helium-gateway-*.tar.gz
 
-  buildx:
+  docker_buildx:
     needs: [hygiene]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:
+          # Needed for 'git describe'
           fetch-depth: 0
 
       - name: Setup Docker buildx
@@ -113,8 +114,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: quay.io
-          username: ${{ secrets.QUAY_TEST_USER }}
-          password: ${{ secrets.QUAY_TEST_UPLOAD_TOKEN }}
+          username: ${{ secrets.QUAY_MINER_USER }}
+          password: ${{ secrets.QUAY_MINER_UPLOAD_TOKEN }}
 
       # We publish all builds to the test-images repo.
       - name: Publish image to test-images repo
@@ -127,12 +128,11 @@ jobs:
 
       # Publish to miner quay-repo on release only.
       - name: Publish release image to miner repo
-        # One time only, lets publish a gwrs image to miner without
-        # the check.
-        # if: startsWith(github.ref, 'refs/tags')
+        if: startsWith(github.ref, 'refs/tags')
         run: |
           docker buildx build \
           --platform linux/arm64,linux/amd64 \
-          --tag quay.io/team-helium/miner:gateway-"$(git describe)" \
+          --tag quay.io/team-helium/miner:gateway-"${GITHUB_REF#refs/*/}" \
+          --tag quay.io/team-helium/miner:gateway-latest \
           --push \
           .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,12 @@ jobs:
           files: helium-gateway-*.tar.gz
 
   buildx:
+    needs: [hygiene]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2
@@ -113,14 +116,23 @@ jobs:
           username: ${{ secrets.QUAY_TEST_USER }}
           password: ${{ secrets.QUAY_TEST_UPLOAD_TOKEN }}
 
-      # The following is for testing this PR only. This will be
-      # replaced with tag-gated publishing to
-      # quay.io/team-helium/test-images, along with proper
-      # git-tag-based image-tags
-      - name: Publish Docker image
+      # We publish all builds to the test-images repo.
+      - name: Publish image to test-images repo
         run: |
           docker buildx build \
           --platform linux/arm64,linux/amd64 \
-          --tag quay.io/team-helium/test-images:gwrs-pr-353 \
+          --tag quay.io/team-helium/test-images:gateway-"$(git describe)" \
+          --push \
+          .
+
+      # Publish to miner quay-repo on release only.
+      - name: Publish release image to miner repo
+        # One time only, lets publish a gwrs image to miner without
+        # the check.
+        # if: startsWith(github.ref, 'refs/tags')
+        run: |
+          docker buildx build \
+          --platform linux/arm64,linux/amd64 \
+          --tag quay.io/team-helium/miner:gateway-"$(git describe)" \
           --push \
           .

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,7 +969,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=jsk/allow-protoc-override#aef60f66f39d8c8170351398b15a229da1941186"
+source = "git+https://github.com/helium/proto?branch=master#c618b4aaf27df932cfc8bcab54e72ee612914e77"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,7 +969,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#dc3b7bbbf1f946b4d70c3d592df036ea3e57e61c"
+source = "git+https://github.com/helium/proto?branch=jsk/allow-protoc-override#aef60f66f39d8c8170351398b15a229da1941186"
 dependencies = [
  "bytes",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = ["lorawan", "beacon"]
 byteorder = "1"
 serde = {version = "1", features = ["rc", "derive"]}
 rust_decimal = {version = "1", features = ["serde-with-float"]}
-helium-proto = { git = "https://github.com/helium/proto", branch="jsk/allow-protoc-override", features=["services"]}
+helium-proto = { git = "https://github.com/helium/proto", branch="master", features=["services"]}
 rand = "0.8"
 base64 = "0"
 sha2 = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = ["lorawan", "beacon"]
 byteorder = "1"
 serde = {version = "1", features = ["rc", "derive"]}
 rust_decimal = {version = "1", features = ["serde-with-float"]}
-helium-proto = { git = "https://github.com/helium/proto", branch="master", features=["services"]}
+helium-proto = { git = "https://github.com/helium/proto", branch="jsk/allow-protoc-override", features=["services"]}
 rand = "0.8"
 base64 = "0"
 sha2 = "0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 # ------------------------------------------------------------------------------
 # Cargo Build Stage
 # ------------------------------------------------------------------------------
-
 FROM rust:alpine as cargo-build
 RUN apk add --no-cache musl-dev cmake protoc gcompat
 WORKDIR /tmp/helium_gateway
@@ -12,7 +11,7 @@ RUN cargo build --release
 # ------------------------------------------------------------------------------
 # Final Stage
 # ------------------------------------------------------------------------------
-FROM rust:alpine
+FROM alpine:3.17.1
 ENV RUST_BACKTRACE=1
 ENV GW_UPDATE_ENABLED=false
 ENV GW_LISTEN="0.0.0.0:1680"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,48 @@
 # ------------------------------------------------------------------------------
 # Cargo Build Stage
+#
+# Runs on native host architecture
+# Cross compiles for target architecture
 # ------------------------------------------------------------------------------
-FROM rust:alpine as cargo-build
-RUN apk add --no-cache musl-dev cmake protoc gcompat
+FROM --platform=$BUILDPLATFORM rust:latest AS cargo-build
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y cmake musl-tools clang llvm -y
+
 WORKDIR /tmp/helium_gateway
 COPY . .
-ENV PROTOC=/usr/bin/protoc
-RUN cargo build --release
+
+ENV CC_aarch64_unknown_linux_musl=clang
+ENV AR_aarch64_unknown_linux_musl=llvm-ar
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"
+
+ENV CC_x86_64_unknown_linux_musl=clang
+ENV AR_x86_64_unknown_linux_musl=llvm-ar
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-Clink-self-contained=yes -Clinker=rust-lld"
+
+ARG TARGETPLATFORM
+RUN \
+case "$TARGETPLATFORM" in \
+    "linux/arm64") echo aarch64-unknown-linux-musl > rust_target.txt ;; \
+    "linux/amd64") echo x86_64-unknown-linux-musl > rust_target.txt ;; \
+    *) exit 1 ;; \
+esac
+
+RUN rustup target add $(cat rust_target.txt)
+
+RUN cargo build --release --target=$(cat rust_target.txt)
+RUN mv target/$(cat rust_target.txt)/release/helium_gateway .
 
 # ------------------------------------------------------------------------------
 # Final Stage
+#
+# Run steps run in a VM based on the target architecture
+# Produces image for target architecture
 # ------------------------------------------------------------------------------
 FROM alpine:3.17.1
 ENV RUST_BACKTRACE=1
-ENV GW_UPDATE_ENABLED=false
 ENV GW_LISTEN="0.0.0.0:1680"
-COPY --from=cargo-build /tmp/helium_gateway/target/release/helium_gateway /usr/local/bin/helium_gateway
+COPY --from=cargo-build /tmp/helium_gateway/helium_gateway /usr/local/bin/helium_gateway
 RUN mkdir /etc/helium_gateway
 COPY config/settings.toml /etc/helium_gateway/settings.toml
 CMD ["helium_gateway", "server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,10 @@
 # ------------------------------------------------------------------------------
 
 FROM rust:alpine as cargo-build
-
 RUN apk add --no-cache musl-dev cmake protoc gcompat
-
 WORKDIR /tmp/helium_gateway
 COPY . .
+ENV PROTOC=/usr/bin/protoc
 RUN cargo build --release
 
 # ------------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,25 @@
+# ==============================================================================
+# This Docker file is designed support multi-architecture[1] images.
+#
+# How you build depends on your use case. If you only want to build
+# for the architecture you're invoking docker from (host arch):
+#
+#     docker build .
+#
+# However, if you want to build for another architecture or multiple
+# architectures, use buildx[2]:
+#
+#     docker buildx build --platform linux/arm64,linux/amd64 .
+#
+# Adding support for additional architectures requires editing the
+# `case "$TARGETPLATFORM" in` in the build stage (and likely quite a
+# bit of googling).
+#
+# 1: https://www.docker.com/blog/how-to-rapidly-build-multi-architecture-images-with-buildx
+# 2: https://docs.docker.com/build/install-buildx
+# ==============================================================================
+
+
 # ------------------------------------------------------------------------------
 # Cargo Build Stage
 #
@@ -32,6 +54,7 @@ RUN rustup target add $(cat rust_target.txt)
 
 RUN cargo build --release --target=$(cat rust_target.txt)
 RUN mv target/$(cat rust_target.txt)/release/helium_gateway .
+
 
 # ------------------------------------------------------------------------------
 # Final Stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@
 FROM --platform=$BUILDPLATFORM rust:latest AS cargo-build
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y cmake musl-tools clang llvm -y
+    apt-get install -y cmake musl-tools clang llvm
 
 WORKDIR /tmp/helium_gateway
 COPY . .


### PR DESCRIPTION
This PR modifies the Dockerfile so that it can be used to produce single images that support multiple architectures. Currently, it supports [`linux/arm64`, `linux/amd64`]. The restriction on those two is only because I chose to perform phase 1 of the build on the host architecture, and not in QEMU.

Example invocation to an image that can run on amd64 and aarch64:

```sh
docker buildx build --platform linux/arm64,linux/amd64 .
```

I left notes in the Dockerfile on how to add additional architecture support. However, if we and our CI infrastructure are fine with the **extremely** long build times, we can modify the Dockerfile to perform both build phases in QUEMU and be compatible with any platforms that `buildx` supports.

# Testing

The only thing can't be tested until merging is if tagging a release results in a properly named tag in the miner quay. That said, publishing to both quay.io/repository/team-helium/miner and quay.io/repository/team-helium/test-images is working.
