### PR TITLE
The seed isn’t enough to generate the data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,7 @@ dependencies = [
  "lazy_static",
  "prost",
  "rand",
+ "rand_chacha",
  "rust_decimal",
  "serde",
  "serde_json",

--- a/beacon/Cargo.toml
+++ b/beacon/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
+rand_chacha = "0"
 prost = {workspace = true}
 helium-proto = {workspace = true}
 rand = {workspace = true}


### PR DESCRIPTION
* This fixes up the beacon data the way it was intended.. the entropy is used to seed an RNG which then generates a random bytes of the requested length
* Sets the required length to 51 to allow for the lora header