### PR TITLE
Publish docker images to quay.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,45 @@ jobs:
           tag_name: ${{ steps.vars.outputs.tag }}
           name: Release ${{ steps.vars.outputs.tag }}
           files: target/pkg/helium-gateway-${{ steps.vars.outputs.tag }}-${{ matrix.target }}.*
+
+  docker_buildx:
+    # Ensure we don't publish images until we pass clippy.
+    needs: [build]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Needed for 'git describe'
+          fetch-depth: 0
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_MINER_USER }}
+          password: ${{ secrets.QUAY_MINER_UPLOAD_TOKEN }}
+
+      # We publish all builds to the test-images repo.
+      - name: Publish image to test-images repo
+        run: |
+          docker buildx build \
+          --platform linux/arm64,linux/amd64 \
+          --tag quay.io/team-helium/test-images:gateway-"$(git describe)" \
+          --push \
+          .
+
+      # Publish to miner quay-repo on release only.
+      - name: Publish release image to miner repo
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          docker buildx build \
+          --platform linux/arm64,linux/amd64 \
+          --tag quay.io/team-helium/miner:gateway-"${GITHUB_REF#refs/*/}" \
+          --tag quay.io/team-helium/miner:gateway-latest \
+          --push \
+          .


### PR DESCRIPTION
This PR adds a new CI build step which pushes docker images to two quay.io repos:

1. All builds go to [quay.io/team-helium/test-images](https://quay.io/repository/team-helium/test-images?tab=tags&tag=latest)
    - helps with testing one-off or experimental builds without clogging up the miner image repo
3. Tag/release builds to go [quay.io/team-helium/miner](https://quay.io/repository/team-helium/miner?tab=tags&tag=latest)