### PR TITLE
Deconstrain fetch to allow for git-describe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
I had removed the fetch-depth argument (unintuitively, 0 means full depth) in #365, forgetting that it's needed for git-describe to work. The reason is that git-describe needs to walk the commit history to know how many commits it's been since the last tag.
