### PR TITLE
Enable TPM+ECC support in docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,6 @@ FROM alpine:3.17.1
 ENV RUST_BACKTRACE=1
 ENV GW_LISTEN="0.0.0.0:1680"
 RUN apk add --no-cache --update \
-    curl \
     libstdc++ \
     tpm2-tss-esys \
     tpm2-tss-fapi \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,14 @@ COPY . .
 
 ENV CC=gcc CXX=g++ CFLAGS="-U__sun__" RUSTFLAGS="-C target-feature=-crt-static"
 
-RUN cargo build --release --no-default-features --features=ecc608,tpm
+# TMP build fail when cross compiling, so we need to use QEMU when
+# building for not-host architectures. But QUEMU builds fail in CI due
+# to OOMing on cargo registry updating. Therefore, we will need to
+# compile with nightly until cargo's sparse registry stabilizes.
+RUN rustup toolchain install nightly
+ENV CARGO_UNSTABLE_SPARSE_REGISTRY=true
+
+RUN cargo +nightly build --release --no-default-features --features=ecc608,tpm
 RUN mv target/release/helium_gateway .
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,22 +22,26 @@
 
 # ------------------------------------------------------------------------------
 # Cargo Build Stage
-#
-# Runs on native host architecture
-# Cross compiles for target architecture
 # ------------------------------------------------------------------------------
 FROM rust:alpine3.17 AS cargo-build
 ARG FEATURES
-RUN apk add --no-cache --update cmake musl-dev clang15-libclang llvm protobuf
-RUN if [[ "$FEATURES" == *"tpm"* ]] ; then apk add tpm2-tss-dev gcc g++ libc-dev ; fi
+RUN apk add --no-cache --update \
+    clang15-libclang \
+    cmake \
+    g++ \
+    gcc \
+    libc-dev \
+    llvm \
+    musl-dev \
+    protobuf \
+    tpm2-tss-dev
 
 WORKDIR /tmp/helium_gateway
 COPY . .
 
-ENV CC=gcc CXX=g++ CFLAGS="-U__sun__" \
-    RUSTFLAGS="-C target-feature=-crt-static"
+ENV CC=gcc CXX=g++ CFLAGS="-U__sun__" RUSTFLAGS="-C target-feature=-crt-static"
 
-RUN cargo build --release --no-default-features --features $FEATURES
+RUN cargo build --release --no-default-features --features=ecc,tpm
 RUN mv target/release/helium_gateway .
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN apk add --no-cache --update \
     g++ \
     gcc \
     libc-dev \
-    llvm \
     musl-dev \
     protobuf \
     tpm2-tss-dev
@@ -41,7 +40,7 @@ COPY . .
 
 ENV CC=gcc CXX=g++ CFLAGS="-U__sun__" RUSTFLAGS="-C target-feature=-crt-static"
 
-RUN cargo build --release --no-default-features --features=ecc,tpm
+RUN cargo build --release --no-default-features --features=ecc608,tpm
 RUN mv target/release/helium_gateway .
 
 
@@ -54,7 +53,15 @@ RUN mv target/release/helium_gateway .
 FROM alpine:3.17.1
 ENV RUST_BACKTRACE=1
 ENV GW_LISTEN="0.0.0.0:1680"
-RUN apk add --no-cache --update curl
+RUN apk add --no-cache --update \
+    curl \
+    libstdc++ \
+    tpm2-tss-esys \
+    tpm2-tss-fapi \
+    tpm2-tss-mu \
+    tpm2-tss-rc \
+    tpm2-tss-tcti-device
+
 COPY --from=cargo-build /tmp/helium_gateway/helium_gateway /usr/local/bin/helium_gateway
 RUN mkdir /etc/helium_gateway
 COPY config/settings.toml /etc/helium_gateway/settings.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ ENV CC=gcc CXX=g++ CFLAGS="-U__sun__" RUSTFLAGS="-C target-feature=-crt-static"
 RUN rustup toolchain install nightly
 ENV CARGO_UNSTABLE_SPARSE_REGISTRY=true
 
-RUN cargo +nightly build --release --no-default-features --features=ecc608,tpm
+RUN cargo +nightly build --release --features=tpm
 RUN mv target/release/helium_gateway .
 
 


### PR DESCRIPTION
I transferred @isergieienkov branch for #374 to this repo so we can test CI.

I was defeated in my attempt to cross-compile with TPM support. So now the build phase happens under QEMU when building for architectures that differ from the host (notice the removal of `--from $BUILDPLATORM`). The downside is that this can be really slow. Additionally, it requires nightly because QEMU OOMs when updating the cargo cache unless we use sparse-registry.