### PR TITLE
Remove —daemon flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,12 +322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "boxfnonce"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5988cb1d626264ac94100be357308f29ff7cbdd3b36bda27f450a4ee3f713426"
-
-[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,16 +517,6 @@ name = "ct-codecs"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
-
-[[package]]
-name = "daemonize"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c24513e34f53b640819f0ac9f705b673fcf4006d7aab8778bee72ebfc89815"
-dependencies = [
- "boxfnonce",
- "libc",
-]
 
 [[package]]
 name = "der"
@@ -840,7 +824,6 @@ dependencies = [
  "cfg-if",
  "clap",
  "config",
- "daemonize",
  "exponential-backoff",
  "futures",
  "helium-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ slog-stdlog = "4"
 thiserror = {workspace = true}
 rand = {workspace = true}
 prost = {workspace = true}
-daemonize = "0.4"
 tonic = "0"
 http = "*"
 log = "0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,13 +17,7 @@ pub struct Cli {
     #[arg(short = 'c', default_value = "/etc/helium_gateway/settings.toml")]
     config: PathBuf,
 
-    /// Daemonize the application
-    #[arg(long)]
-    daemon: bool,
-
     /// Monitor stdin and terminate when stdin closes.
-    ///
-    /// This flag is not cmopatible with the daemon flag
     #[arg(long)]
     stdin: bool,
 
@@ -79,12 +73,6 @@ fn mk_logger(settings: &Settings) -> Logger {
 
 pub fn main() -> Result {
     let cli = Cli::parse();
-    if cli.daemon {
-        daemonize::Daemonize::new()
-            .pid_file(format!("/var/run/{}.pid", env!("CARGO_BIN_NAME")))
-            .start()
-            .expect("daemon start");
-    }
 
     let settings = Settings::new(&cli.config)?;
 
@@ -108,7 +96,7 @@ pub fn main() -> Result {
             .build()
             .expect("runtime build");
 
-        // Start the runtime after the daemon fork
+        // Start the runtime
         let res = runtime.block_on(async {
             let (shutdown_trigger, shutdown_listener) = triggered::trigger();
             tokio::spawn(async move {


### PR DESCRIPTION
Removes the —daemon flag and feature from helium_gateway since it is no longer maintained and did not work well.

The use can be replaced by a proper use of an init like unlix process to control the fork behavior