### PR TITLE
update proto for oracle compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,7 +915,7 @@ dependencies = [
 [[package]]
 name = "helium-proto"
 version = "0.1.0"
-source = "git+https://github.com/helium/proto?branch=master#54e01c167b6c1fad535db992139dade776bcda14"
+source = "git+https://github.com/helium/proto?branch=master#4afcaaea25bde4e333f1e57fc32f163910e8ca0a"
 dependencies = [
  "bytes",
  "prost",


### PR DESCRIPTION
updates the version of helium-proto to allow cargo to resolve rand crate/trait dependency confusion between the one it defines and the one it pulls transitively via the beacon subcrate here