### PR TITLE
Update GW_LISTEN

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN mv target/release/helium_gateway .
 # ------------------------------------------------------------------------------
 FROM alpine:3.17.1
 ENV RUST_BACKTRACE=1
-ENV GW_LISTEN="0.0.0.0:1680"
+ENV GW_LISTEN="127.0.0.1:1680"
 RUN apk add --no-cache --update \
     libstdc++ \
     tpm2-tss-esys \


### PR DESCRIPTION
GW_LISTEN is 127.0.0.1:1680 in the official Helium documentation, but GW_LISTEN is 0.0.0.0:1680 in Dockerfile, refer to the link: https://docs.helium.com/solana/migration/maker-hotspot-software/#quick-reference-summary