### PR TITLE
Add support for port or complete api socketaddr

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -14,8 +14,9 @@ keypair = "/etc/helium_gateway/gateway_key.bin"
 # The address to listen on for the (semtech) packet forwarder
 listen = "127.0.0.1:1680"
 
-# The local port to serve the local grpc on. 
-# Do NOT expose this port outside of the host network for security
+# The local port to serve the local grpc on. Supports both a simple port number
+# or full ip:port listen address. Do NOT expose this port outside of the host
+# network for security
 api = 4467
 
 # The default region to use until a region is received from the Helium network.

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -1,7 +1,9 @@
-use super::{connect_uri, AddGatewayReq, GatewayStakingMode, PubkeyReq, RegionReq, RouterReq};
+use super::{AddGatewayReq, GatewayStakingMode, PubkeyReq, RegionReq, RouterReq};
 use crate::{
-    error::Error, packet_router::RouterStatus, settings::StakingMode, PublicKey, Region, Result,
-    TxnEnvelope,
+    error::Error,
+    packet_router::RouterStatus,
+    settings::{ListenAddress, StakingMode},
+    PublicKey, Region, Result, TxnEnvelope,
 };
 use helium_proto::{services::local::Client, BlockchainTxnAddGatewayV1};
 use std::convert::TryFrom;
@@ -12,9 +14,9 @@ pub struct LocalClient {
 }
 
 impl LocalClient {
-    pub async fn new(port: u16) -> Result<Self> {
-        let uri = connect_uri(port);
-        let endpoint = Endpoint::from_shared(uri).unwrap();
+    pub async fn new(address: &ListenAddress) -> Result<Self> {
+        let uri = http::Uri::try_from(address)?;
+        let endpoint = Endpoint::from_shared(uri.to_string()).unwrap();
         let client = Client::connect(endpoint)
             .await
             .map_err(Error::local_client_connect)?;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,8 +1,6 @@
 mod client;
 mod server;
 
-const LISTEN_ADDR: &str = "127.0.0.1";
-
 pub use client::LocalClient;
 pub use helium_proto::{
     services::local::{
@@ -12,15 +10,6 @@ pub use helium_proto::{
     GatewayStakingMode,
 };
 pub use server::LocalServer;
-
-pub fn listen_addr(port: u16) -> String {
-    format!("{LISTEN_ADDR}:{port}")
-}
-
-pub fn connect_uri(port: u16) -> String {
-    let listen_addr = listen_addr(port);
-    format!("http://{listen_addr}")
-}
 
 use crate::{Error, Result};
 

--- a/src/cmd/add.rs
+++ b/src/cmd/add.rs
@@ -23,7 +23,7 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, settings: Settings) -> Result {
-        let mut client = LocalClient::new(settings.api).await?;
+        let mut client = LocalClient::new(&settings.api).await?;
 
         let txn = client
             .add_gateway(&self.owner, &self.payer, &self.mode)

--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -56,16 +56,16 @@ impl fmt::Display for InfoKey {
     }
 }
 struct InfoCache {
-    port: u16,
+    address: settings::ListenAddress,
     public_keys: Option<(PublicKey, PublicKey)>,
     region: Option<Region>,
     router: Option<RouterStatus>,
 }
 
 impl InfoCache {
-    fn new(port: u16) -> Self {
+    fn new(address: settings::ListenAddress) -> Self {
         Self {
-            port,
+            address,
             public_keys: None,
             region: None,
             router: None,
@@ -76,7 +76,7 @@ impl InfoCache {
         if let Some(public_keys) = &self.public_keys {
             return Ok(public_keys.clone());
         }
-        let mut client = LocalClient::new(self.port).await?;
+        let mut client = LocalClient::new(&self.address).await?;
         let public_keys = client.pubkey().await?;
         self.public_keys = Some(public_keys.clone());
         Ok(public_keys)
@@ -96,7 +96,7 @@ impl InfoCache {
         if let Some(region) = self.region {
             return Ok(region);
         }
-        let mut client = LocalClient::new(self.port).await?;
+        let mut client = LocalClient::new(&self.address).await?;
         let region = client.region().await?;
         self.region = Some(region);
         Ok(region)
@@ -106,7 +106,7 @@ impl InfoCache {
         if let Some(router) = &self.router {
             return Ok(router.clone());
         }
-        let mut client = LocalClient::new(self.port).await?;
+        let mut client = LocalClient::new(&self.address).await?;
         let router = client.router().await?;
         self.router = Some(router.clone());
         Ok(router)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -18,7 +18,7 @@ pub struct Settings {
     /// The listening network port for the grpc / jsonrpc API.
     /// Default 4467
     #[serde(default = "default_api")]
-    pub api: u16,
+    pub api: ListenAddress,
     /// The location of the keypair binary file for the gateway. If the keyfile
     /// is not found there a new one is generated and saved in that location.
     pub keypair: Arc<Keypair>,
@@ -136,8 +136,8 @@ fn default_listen() -> String {
     "127.0.0.1:1680".to_string()
 }
 
-fn default_api() -> u16 {
-    4467
+fn default_api() -> ListenAddress {
+    ListenAddress::Address("127.0.0.1:4467".to_string())
 }
 
 fn default_poc_interval() -> u64 {
@@ -183,6 +183,75 @@ impl fmt::Display for StakingMode {
             .fmt(f)
     }
 }
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum ListenAddress {
+    Port(u16),
+    Address(String),
+}
+
+impl TryFrom<&ListenAddress> for std::net::SocketAddr {
+    type Error = crate::Error;
+    fn try_from(value: &ListenAddress) -> std::result::Result<Self, Self::Error> {
+        match value {
+            ListenAddress::Address(str) => Ok(str.parse()?),
+            ListenAddress::Port(v) => Ok(format!("127.0.0.1:{v}").parse()?),
+        }
+    }
+}
+
+impl TryFrom<&ListenAddress> for http::Uri {
+    type Error = crate::Error;
+    fn try_from(value: &ListenAddress) -> std::result::Result<Self, Self::Error> {
+        match value {
+            ListenAddress::Address(str) => Ok(Uri::from_str(&format!("http://{str}"))?),
+            ListenAddress::Port(v) => Ok(Uri::from_str(&format!("http://127.0.0.1:{v}"))?),
+        }
+    }
+}
+
+// pub mod api {
+//     use serde::de;
+
+//     pub fn deserialize<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
+//     where
+//         D: de::Deserializer<'de>,
+//     {
+//         struct _Visitor;
+
+//         impl<'de> de::Visitor<'de> for _Visitor {
+//             type Value = String;
+//             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+//                 formatter.write_str("api listen port or address")
+//             }
+
+//             fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+//             where
+//                 E: de::Error,
+//             {
+//                 Ok(format!("127.0.0.1:{v}"))
+//             }
+
+//             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+//             where
+//                 E: de::Error,
+//             {
+//                 Ok(format!("127.0.0.1:{v}"))
+//             }
+
+//             fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+//             where
+//                 E: de::Error,
+//             {
+//                 Ok(value.to_string())
+//             }
+//         }
+
+//         eprintln!("visiting");
+//         deserializer.deserialize_any(_Visitor)
+//     }
+// }
 
 pub mod log_level {
     use serde::de::{self, Deserialize, Deserializer, Visitor};


### PR DESCRIPTION
This adds support for the local listen address to be either a port or a fully specified `ip:port` listen address. It is _RECOMMENDED_ to only use the port configuration (which defaults the ip to local host listening only) to avoid exposing local apis to the open internet. 

