### PR TITLE
Do not package attestation manifests with docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,10 @@ jobs:
 
       # We publish all builds to the test-images repo.
       - name: Build | Test Image
+        env:
+          # The attestation manifests cause build errors for some makers.
+          # See https://github.com/helium/gateway-rs/issues/409
+          BUILDX_NO_DEFAULT_ATTESTATIONS: 1
         run: |
           docker buildx build \
           --platform linux/arm64,linux/amd64 \
@@ -174,6 +178,10 @@ jobs:
 
       # Publish to miner quay-repo on release only.
       - name: Build | Release Image
+        env:
+          # The attestation manifests cause build errors for some makers.
+          # See https://github.com/helium/gateway-rs/issues/409
+          BUILDX_NO_DEFAULT_ATTESTATIONS: 1
         if: startsWith(github.ref, 'refs/tags')
         run: |
           docker buildx build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,6 @@
 #
 #     docker buildx build --platform linux/arm64,linux/amd64 .
 #
-# Adding support for additional architectures requires editing the
-# `case "$TARGETPLATFORM" in` in the build stage (and likely quite a
-# bit of googling).
-#
 # 1: https://www.docker.com/blog/how-to-rapidly-build-multi-architecture-images-with-buildx
 # 2: https://docs.docker.com/build/install-buildx
 # ==============================================================================


### PR DESCRIPTION
These manifests break some users' builds when using these images as base-images.

Closes #409 