### PR TITLE
feat: add builds and use prebuilt action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           - aarch64-unknown-linux-musl
           - mips-unknown-linux-musl
           - mipsel-unknown-linux-musl
+          - x86_64-unknown-debian-gnu
           - x86_64-tpm-debian-gnu
 
     steps:
@@ -142,10 +143,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup | QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Setup | Docker
         uses: docker/setup-buildx-action@v2
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
 
       - name: Setup | Quay.io
         uses: docker/login-action@v2
@@ -164,30 +168,33 @@ jobs:
 
       # We publish all builds to the test-images repo.
       - name: Build | Test Image
+        uses: docker/build-push-action@v3
         env:
           # The attestation manifests cause build errors for some makers.
           # See https://github.com/helium/gateway-rs/issues/409
           BUILDX_NO_DEFAULT_ATTESTATIONS: 1
-        run: |
-          docker buildx build \
-          --platform linux/arm64,linux/amd64 \
-          --label VERSION="${{ env.image_tag }}" \
-          --tag quay.io/team-helium/test-images:gateway-"${{ env.image_tag }}" \
-          --push \
-          .
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          labels: VERSION="${{ env.image_tag }}"
+          tags: quay.io/team-helium/test-images:gateway-"${{ env.image_tag }}"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # Publish to miner quay-repo on release only.
       - name: Build | Release Image
+        if: startsWith(github.ref, 'refs/tags')
+        uses: docker/build-push-action@v3
         env:
           # The attestation manifests cause build errors for some makers.
           # See https://github.com/helium/gateway-rs/issues/409
           BUILDX_NO_DEFAULT_ATTESTATIONS: 1
-        if: startsWith(github.ref, 'refs/tags')
-        run: |
-          docker buildx build \
-          --platform linux/arm64,linux/amd64 \
-          --label VERSION="${GITHUB_REF#refs/*/}" \
-          --tag quay.io/team-helium/miner:gateway-"${GITHUB_REF#refs/*/}" \
-          --tag quay.io/team-helium/miner:gateway-latest \
-          --push \
-          .
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          labels: VERSION="${GITHUB_REF#refs/*/}"
+          tags: | 
+            quay.io/team-helium/miner:gateway-"${GITHUB_REF#refs/*/}" \
+            quay.io/team-helium/miner:gateway-latest \
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -4,6 +4,10 @@ FEATURES = "ecc608"
 BUILD_COMMAND = "cross"
 TAR = { source = "${CARGO_MAKE_RUST_TARGET_OS}", default_value = "linux", mapping = { macos = "gtar", linux = "tar" } }
 
+[env.x86_64-unknown-debian-gnu]
+CROSS_TARGET = "x86_64-unknown-linux-gnu"
+CROSS_BUILD_DOCKERFILE = "./.github/cross-docker/Dockerfile-cross-debian-11"
+
 [env.x86_64-tpm-debian-gnu]
 CROSS_TARGET = "x86_64-unknown-linux-gnu"
 CROSS_BUILD_DOCKERFILE = "./.github/cross-docker/Dockerfile-cross-debian-11"

--- a/README.md
+++ b/README.md
@@ -25,17 +25,19 @@ In turn, the Helium Gateway application does two things:
                                                                  +-----------+
 ```
 
-**NOTE**: A Helium Gateway based hotspot is eligible for data rewards **only**.
-Proof of coverage rewards are only possible for approved maker hotspots.
+**NOTE**: A DIY Helium Gateway based hotspot is eligible for data rewards **only**.
+Proof of coverage rewards are only possible for [approved maker hotspots](https://github.com/dewi-alliance/hotspot-manufacturers).
 
 ### Releases
 
 The project builds binary compressed tar
 [release](https://github.com/helium/gateway-rs/releases) files which are named
 after the crypto module used and the cpu architecture they were built for. For
-example `helium-gateway-ecc608-aarch64-unknown-linux-gnu.tar.gz` contains the
+example `helium-gateway-1.0.0-aarch64-unknown-linux-gnu.tar.gz` contains the
 `helium_gateway` executable with ecc608 support and it's `setttings.toml`
 configuration file.
+
+For versions using the ecc608, the crypto module name is not included in the file name. However for TPM variants it is included, for example `helium-gateway-1.0.0-x86_64-tpm-debian-gnu.tar.gz`
 
 Releases are tagged using [semantic versioning](https://semver.org) with a
 `major.minor.patch` form. A alpha/beta release tags may also be issued for early
@@ -83,13 +85,13 @@ helium-gateway pre-installed, manual installation requires you to:
    the `syslog` service on your device to accept the logs.
 
 6. Configure the region if required. The default region of the gateway is set to
-   `UKNOWN`, and fetched based on the asserted location of the gateway. Setting
+   `UNKNOWN`, and fetched based on the asserted location of the gateway. Setting
    the region to a known region or caching the last fetched region and using
    the `GW_REGION` environment variable on startup will allow the gateway to use
    the correct region for uplinks immediately, while the region parameters are
    retrieved.
 
-   The supported region values are listed in the [region protobuf definition](https://github.com/helium/proto/blob/master/src/region.proto)
+   The supported region values are listed in the [region protobuf definition](https://github.com/helium/proto/blob/master/src/region.proto).
 
    **NOTE**: Due to TX power regulations, the gateway location needs to be
    asserted on the blockchain to be able to send downlinks.
@@ -145,8 +147,10 @@ Note that platforms will be tested much faster if you join the development proce
 |                                | :white_check_mark: [Kona Micro] IoT Gateway                                                                                 |
 |                                | :white_check_mark: [Kona Enterprise] IoT Gateway                                                                            |
 |                                | :white_check_mark: [RisingHF RHF2S027] Light Hotspot                                                                        |
+| x86_64-unknown-linux-gnu       | :white_check_mark: Debian x86_64 (ecc608)                                                                                   |
+|                                | :white_check_mark: LongAP                                                                                                   |
 | x86_64-tpm-debian-gnu          | :white_check_mark: Debian x86_64 (tpm)                                                                                      |
-|                                | :white_check_mark: FreedomfFi gateway                                                                                       |
+|                                | :white_check_mark: FreedomFi gateway                                                                                        |
 
 [rak833]: https://github.com/RAKWireless/RAK2247-RAK833-LoRaGateway-OpenWRT-MT7628
 [rak7258]: https://store.rakwireless.com/products/rak7258-micro-gateway
@@ -243,6 +247,18 @@ configured for use.
 
 See the [gateway-mfr-rs repo](https://github.com/helium/gateway-mfr-rs) for
 instructions on configuring, locking, and testing an ECC chip.
+
+It is expected that most gateways will use the same key slot for the onboarding key and the keypair, however this key is also configurable in the same way as the keypair:
+
+```
+onboarding = "ecc://i2c-1:96?slot=0"
+```
+
+The original helium miners use an onboarding key on slot 15:
+
+```
+onboarding = "ecc://i2c-1:96?slot=15"
+```
 
 ### Envrionment variables
 
@@ -443,3 +459,7 @@ However as discussed above you can also pass the `-c` option to tell the service
 ```
 ./helium_gateway -c /location/of/config/file server
 ```
+
+## More docs and info
+
+There is a wealth of further information on maker hotspot software on the [Helium Docs site](https://docs.helium.com/solana/migration/maker-hotspot-software/) including information about the [gRPC api](https://github.com/helium/gateway-rs/tree/main/src/api) that allows you to interact with the gateway via the maker app and other services over gRPC rather than via the command line options described above.


### PR DESCRIPTION
- add ecc608 based x86_64 image (LongAP uses this configuration)
- add docker builds for armv6 and armv7 via qemu
- change the build and push step to use the prebuilt docker action
- add github actions cache to builder action step to speed up future builds
- fix typos and add a bit more detail to readme

~~- gateway-mfr-rs uses aarch64-unknown-linux-gnu instead of aarch64-unknown-linux-musl so this unifies the two~~
~~- adds missing armv7-unknown-linux-gnueabihf which is built in gateway-mfr-rs~~