### PR TITLE
Increase the number of hpr connect backof steps

### DIFF
--- a/src/packet_router/mod.rs
+++ b/src/packet_router/mod.rs
@@ -22,7 +22,7 @@ use tracing::{debug, info, warn};
 
 const STORE_GC_INTERVAL: Duration = Duration::from_secs(60);
 
-const RECONNECT_BACKOFF_RETRIES: u32 = 20;
+const RECONNECT_BACKOFF_RETRIES: u32 = 40;
 const RECONNECT_BACKOFF_MIN_WAIT: Duration = Duration::from_secs(5);
 const RECONNECT_BACKOFF_MAX_WAIT: Duration = Duration::from_secs(1800); // 30 minutes
 


### PR DESCRIPTION
This means hotspots will try more often earlier on as they back of which would get them to connect faster given the host rate protections in place