### PR TITLE
Fix older rust resolver

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub mod sync;
 mod api;
 mod base64;
 
-pub(crate) use base64::*;
+pub(crate) use crate::base64::Base64;
 pub use beacon::{Region, RegionParams};
 pub use error::{Error, Result};
 pub use keyed_uri::KeyedUri;


### PR DESCRIPTION
rustc 1.70 can’t figure out which `base64` we’re referring to.

be more explicit about what we’re using from where

Fixes #463 