### PR TITLE
Windowed Beacons

### DIFF
--- a/src/beaconer.rs
+++ b/src/beaconer.rs
@@ -66,7 +66,11 @@ impl Beaconer {
     ) -> Self {
         let interval = Duration::seconds(settings.poc.interval as i64);
         let entropy_uri = settings.poc.entropy_uri.clone();
-        let service = PocIotService::new(settings.poc.ingest_uri.clone(), settings.keypair.clone());
+        let service = PocIotService::new(
+            "beaconer",
+            settings.poc.ingest_uri.clone(),
+            settings.keypair.clone(),
+        );
         let reconnect = Reconnect::default();
         let region_params = Arc::new(region_watcher::current_value(&region_watch));
         let disabled = settings.poc.disable;

--- a/src/beaconer.rs
+++ b/src/beaconer.rs
@@ -414,7 +414,7 @@ mod test {
         let next_segment = current_segment + interval;
         assert!(current_time < next_segment);
 
-        // No beacom time, should pick a time in the current segment
+        // No beacon time, should pick a time in the current segment
         {
             let next_time = mk_next_beacon_time(current_time, None, interval);
             assert!(next_time > current_time);

--- a/src/beaconer.rs
+++ b/src/beaconer.rs
@@ -145,6 +145,10 @@ impl Beaconer {
                             self.interval,
                         );
 
+                        // Log next beacom time if changed
+                        if Some(new_beacon_time) != self.next_beacon_time {
+                            info!(beacon_time = %new_beacon_time, "next beacon time");
+                        }
                         self.next_beacon_time = Some(new_beacon_time);
                         next_beacon_instant = Instant::now() + (new_beacon_time - new_timestamp);
 

--- a/src/beaconer.rs
+++ b/src/beaconer.rs
@@ -238,7 +238,7 @@ impl Beaconer {
     }
 
     async fn handle_beacon_tick(&mut self) {
-        // Ned to clone to allow the subsequence borrow of self for send_beacon.
+        // Need to clone to allow the subsequence borrow of self for send_beacon.
         // The Arc around the region_params makes this a cheap clone
         let region_params = self.region_params.clone();
         let last_beacon = Self::mk_beacon(&region_params, self.entropy_uri.clone())

--- a/src/beaconer.rs
+++ b/src/beaconer.rs
@@ -238,6 +238,8 @@ impl Beaconer {
     }
 
     async fn handle_beacon_tick(&mut self) {
+        // Ned to clone to allow the subsequence borrow of self for send_beacon.
+        // The Arc around the region_params makes this a cheap clone
         let region_params = self.region_params.clone();
         let last_beacon = Self::mk_beacon(&region_params, self.entropy_uri.clone())
             .inspect_err(|err| warn!(%err, "construct beacon"))
@@ -409,7 +411,6 @@ mod test {
         let current_time = datetime!(2023-09-01 09:20 UTC);
 
         let current_segment = duration_trunc(current_time, interval);
-        assert_eq!(current_segment, duration_trunc(current_time, interval));
         let next_segment = current_segment + interval;
         assert!(current_time < next_segment);
 

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -118,7 +118,7 @@ impl Gateway {
                         // Only log if region parameters have changed to avoid
                         // log noise
                         if self.region_params != new_region_params {
-                            info!(region = RegionParams::to_string(&self.region_params), "region updated");
+                            info!(region = RegionParams::to_string(&new_region_params), "region updated");
                         }
                         self.region_params = new_region_params;
                     }

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -114,8 +114,13 @@ impl Gateway {
                 },
                 region_change = self.region_watch.changed() => match region_change {
                     Ok(()) => {
-                        self.region_params = region_watcher::current_value(&self.region_watch);
-                        info!(region = RegionParams::to_string(&self.region_params), "region updated");
+                        let new_region_params = region_watcher::current_value(&self.region_watch);
+                        // Only log if region parameters have changed to avoid
+                        // log noise
+                        if self.region_params != new_region_params {
+                            info!(region = RegionParams::to_string(&self.region_params), "region updated");
+                        }
+                        self.region_params = new_region_params;
                     }
                     Err(_) => warn!("region watch disconnected")
                 },

--- a/src/region_watcher.rs
+++ b/src/region_watcher.rs
@@ -78,9 +78,9 @@ impl RegionWatcher {
                     Ok(None) => (),
                     Ok(Some(remote_params)) => {
                         self.request_retry = REGION_BACKOFF_RETRIES + 1;
-                        if remote_params != *self.watch.borrow() {
-                            _ = self.watch.send_replace(remote_params);
-                        };
+                        // We do not check for a change in params here since we
+                        // want to propagate the timestamp in the remote params
+                        _ = self.watch.send_replace(remote_params);
                     },
                 }
             }

--- a/src/service/packet_router.rs
+++ b/src/service/packet_router.rs
@@ -100,7 +100,7 @@ impl std::ops::DerefMut for PacketRouterService {
 impl PacketRouterService {
     pub fn new(uri: Uri, keypair: Arc<Keypair>) -> Self {
         let client = PacketRouterConduitClient {};
-        Self(ConduitService::new(uri, client, keypair))
+        Self(ConduitService::new("packet_router", uri, client, keypair))
     }
 
     pub async fn send_uplink(&mut self, mut msg: PacketRouterPacketUpV1) -> Result {

--- a/src/service/poc.rs
+++ b/src/service/poc.rs
@@ -81,9 +81,9 @@ impl std::ops::DerefMut for PocIotService {
 }
 
 impl PocIotService {
-    pub fn new(uri: Uri, keypair: Arc<Keypair>) -> Self {
+    pub fn new(module: &'static str, uri: Uri, keypair: Arc<Keypair>) -> Self {
         let client = PocIotConduitClient {};
-        Self(ConduitService::new(uri, client, keypair))
+        Self(ConduitService::new(module, uri, client, keypair))
     }
 
     pub async fn send(&mut self, msg: lora_stream_request_v1::Request) -> Result {


### PR DESCRIPTION
* With the IoT verifier using "any one beacon in known 6 hour windows" this PR adjusts the gateway beaconer to beacon at a completely random time in the six hour window. This _may_ introduce a single invalid beacon on every hotspot/helium_gateway restart again. 

* Adds a `module` tag to the service conduit log output to distinguish beaconed from packet router