### PR TITLE
conduit connected check fix

### DIFF
--- a/src/service/conduit.rs
+++ b/src/service/conduit.rs
@@ -149,7 +149,7 @@ impl<U, D, C: ConduitClient<U, D>> ConduitService<U, D, C> {
     }
 
     pub fn is_connected(&self) -> bool {
-        self.conduit.is_some()
+        self.conduit.is_some() && self.session_keypair.is_some()
     }
 
     pub fn gateway_key(&self) -> &PublicKey {


### PR DESCRIPTION
A conduit is really only connected if it has a stream to the server _and_ the session keypair is established