### PR TITLE
fix display of PacketUp

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -50,10 +50,16 @@ impl From<PacketRouterPacketDownV1> for PacketDown {
 
 impl fmt::Display for PacketUp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut decimal = self.0.frequency.to_string();
+        // insert period before the last 6 digits
+        decimal.insert(decimal.len() - 6, '.');
+        // remove trailing 0's
+        decimal = decimal.trim_end_matches('0').to_string();
+
         f.write_fmt(format_args!(
-            "@{} us, {:.2} MHz, {:?}, snr: {}, rssi: {}, len: {}",
+            "@{} us, {} MHz, {:?}, snr: {}, rssi: {}, len: {}",
             self.0.timestamp,
-            self.0.frequency,
+            decimal,
             self.0.datarate(),
             self.0.snr,
             self.0.rssi,

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -50,16 +50,23 @@ impl From<PacketRouterPacketDownV1> for PacketDown {
 
 impl fmt::Display for PacketUp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut decimal = self.0.frequency.to_string();
-        // insert period before the last 6 digits
-        decimal.insert(decimal.len() - 6, '.');
-        // remove trailing 0's
-        decimal = decimal.trim_end_matches('0').to_string();
+        let mut frequency = self.0.frequency.to_string();
+        if frequency.len() > 6 {
+            // insert period before the last 6 digits
+            frequency.insert(frequency.len() - 6, '.');
+            // remove trailing 0's
+            frequency = frequency.trim_end_matches('0').to_string();
+            // append MHz to the string
+            frequency.push_str(" MHz");
+        } else {
+            // return in Hz
+            frequency.push_str(" Hz");
+        }
 
         f.write_fmt(format_args!(
-            "@{} us, {} MHz, {:?}, snr: {}, rssi: {}, len: {}",
+            "@{} us, {}, {:?}, snr: {}, rssi: {}, len: {}",
             self.0.timestamp,
-            decimal,
+            frequency,
             self.0.datarate(),
             self.0.snr,
             self.0.rssi,


### PR DESCRIPTION
I believe the display implementation was copied from [semtech-udp](https://github.com/helium/semtech-udp/blob/eccaa208126aca962b6b349320fafe6712a6ec79/src/packet/push_data.rs#L219-L237).

However, frequency in that context is unfortunately a f64, but here it is a usize MHz. This PR displays it in human friendly MHz without using additional dependencies.