### PR TITLE
Fix off-by-one error in message cache size limit

### DIFF
--- a/src/message_cache.rs
+++ b/src/message_cache.rs
@@ -51,7 +51,7 @@ impl<T: PartialEq> MessageCache<T> {
     /// (first) message in the cache to be dropped.
     pub fn push_back(&mut self, message: T, received: Instant) -> Option<CacheMessage<T>> {
         self.cache.push_back(CacheMessage::new(message, received));
-        if self.len() > self.max_messages as usize {
+        if self.len() >= self.max_messages as usize {
             self.cache.pop_front()
         } else {
             None
@@ -85,7 +85,7 @@ impl<T: PartialEq> MessageCache<T> {
     /// Pushing to the front of a full cache will cause the given message to not
     /// be added.
     pub fn push_front(&mut self, cache_message: CacheMessage<T>) {
-        if self.len() > self.max_messages as usize {
+        if self.len() >= self.max_messages as usize {
             return;
         }
         self.cache.push_front(cache_message);


### PR DESCRIPTION
The cache was allowing max_messages + 1 items before trimming because the boundary check used `>` instead of `>=`. This caused the cache to exceed its intended maximum size by one element.

Changed the comparison operator from `>` to `>=` in both:
- `push_back()` method
- `push_front()` method

This ensures the cache is trimmed when it reaches the maximum size, not when it exceeds it.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.